### PR TITLE
fix(vibrant-components): keyPress 이벤트를 keyDown으로 변경하고 input관련 prop을 추가한다

### DIFF
--- a/packages/vibrant-components/src/lib/Input/Input.spec.tsx
+++ b/packages/vibrant-components/src/lib/Input/Input.spec.tsx
@@ -7,7 +7,7 @@ import { Input } from './Input';
 describe('<Input />', () => {
   const mockHandleFocus = jest.fn();
   const mockHandleBlur = jest.fn();
-  const mockHandleKeyPress = jest.fn();
+  const mockHandleKeyDown = jest.fn();
   const mockHandleValueChange = jest.fn();
 
   const { render } = createReactRenderer();
@@ -19,7 +19,7 @@ describe('<Input />', () => {
 
     mockHandleBlur.mockClear();
 
-    mockHandleKeyPress.mockClear();
+    mockHandleKeyDown.mockClear();
 
     mockHandleValueChange.mockClear();
   });
@@ -30,7 +30,7 @@ describe('<Input />', () => {
         <Input
           onFocus={mockHandleFocus}
           onBlur={mockHandleBlur}
-          onKeyPress={({ key }) => mockHandleKeyPress(key)}
+          onKeyDown={({ key }) => mockHandleKeyDown(key)}
           onValueChange={mockHandleValueChange}
         />
       );
@@ -63,8 +63,8 @@ describe('<Input />', () => {
         await waitFor(() => userEvent.type(inputElement, 'a'));
       });
 
-      it('keyPress event should called with entered value', () => {
-        expect(mockHandleKeyPress).toBeCalledWith('a');
+      it('keyDown event should called with entered value', () => {
+        expect(mockHandleKeyDown).toBeCalledWith('a');
       });
 
       it('valueChange event should called with entered value', () => {
@@ -83,8 +83,8 @@ describe('<Input />', () => {
         userEvent.paste('123asdf456');
       });
 
-      it('keyPress event should not called', () => {
-        expect(mockHandleKeyPress).not.toBeCalled();
+      it('keyDown event should not called', () => {
+        expect(mockHandleKeyDown).not.toBeCalled();
       });
 
       it('valueChange event should called with entered value', () => {
@@ -102,7 +102,7 @@ describe('<Input />', () => {
       renderer = render(
         <Input
           allowPattern={/\d/}
-          onKeyPress={({ key }) => mockHandleKeyPress(key)}
+          onKeyDown={({ key }) => mockHandleKeyDown(key)}
           onValueChange={mockHandleValueChange}
         />
       );
@@ -111,7 +111,7 @@ describe('<Input />', () => {
     });
 
     afterEach(() => {
-      mockHandleKeyPress.mockClear();
+      mockHandleKeyDown.mockClear();
 
       mockHandleValueChange.mockClear();
     });
@@ -121,8 +121,8 @@ describe('<Input />', () => {
         await waitFor(() => userEvent.type(inputElement, 'a'));
       });
 
-      it('keyPress event should called with entered value', () => {
-        expect(mockHandleKeyPress).toBeCalledWith('a');
+      it('keyDown event should called with entered value', () => {
+        expect(mockHandleKeyDown).toBeCalledWith('a');
       });
 
       it('valueChange event should not called', () => {
@@ -139,8 +139,8 @@ describe('<Input />', () => {
         await waitFor(() => userEvent.type(inputElement, '1'));
       });
 
-      it('keyPress event should called with entered value', () => {
-        expect(mockHandleKeyPress).toBeCalledWith('1');
+      it('keyDown event should called with entered value', () => {
+        expect(mockHandleKeyDown).toBeCalledWith('1');
       });
 
       it('valueChange event should called with entered value', () => {
@@ -159,8 +159,8 @@ describe('<Input />', () => {
         userEvent.paste('123asdf456');
       });
 
-      it('keyPress event should not called', () => {
-        expect(mockHandleKeyPress).not.toBeCalled();
+      it('keyDown event should not called', () => {
+        expect(mockHandleKeyDown).not.toBeCalled();
       });
 
       it('valueChange event should called with replaced value', () => {

--- a/packages/vibrant-components/src/lib/Input/Input.stories.tsx
+++ b/packages/vibrant-components/src/lib/Input/Input.stories.tsx
@@ -1,5 +1,4 @@
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@vibrant-ui/core';
 import { Input } from './Input';
 
 export default {
@@ -25,9 +24,4 @@ export default {
   },
 } as ComponentMeta<typeof Input>;
 
-export const Basic: ComponentStory<typeof Input> = props => (
-  <Box>
-    <Input {...props} />
-    <Input />
-  </Box>
-);
+export const Basic: ComponentStory<typeof Input> = props => <Input {...props} />;

--- a/packages/vibrant-components/src/lib/Input/Input.tsx
+++ b/packages/vibrant-components/src/lib/Input/Input.tsx
@@ -1,55 +1,63 @@
-import type { ForwardedRef, SyntheticEvent } from 'react';
-import { forwardRef } from 'react';
+import type { SyntheticEvent } from 'react';
 import { Box } from '@vibrant-ui/core';
 import { withInputVariation } from './InputProps';
 
 export const Input = withInputVariation(
-  forwardRef(
-    (
-      { placeholder, defaultValue, onFocus, onBlur, onKeyPress, onValueChange, isValidValue, replaceValue },
-      ref: ForwardedRef<HTMLInputElement>
-    ) => (
-      <Box
-        ref={ref}
-        as="input"
-        placeholder={placeholder}
-        value={defaultValue}
-        onPaste={(event: SyntheticEvent<HTMLInputElement, ClipboardEvent>) => {
-          const inputValue = event.nativeEvent.clipboardData?.getData('text') ?? '';
+  ({
+    innerRef,
+    defaultValue,
+    placeholder,
+    maxLength,
+    onFocus,
+    onBlur,
+    onKeyDown,
+    onValueChange,
+    isValidValue,
+    replaceValue,
+    ...restProps
+  }) => (
+    <Box
+      ref={innerRef}
+      as="input"
+      value={defaultValue}
+      placeholder={placeholder}
+      maxLength={maxLength}
+      onPaste={(event: SyntheticEvent<HTMLInputElement, ClipboardEvent>) => {
+        const inputValue = event.nativeEvent.clipboardData?.getData('text') ?? '';
 
-          if (isValidValue(inputValue)) {
-            return;
-          }
+        if (isValidValue(inputValue)) {
+          return;
+        }
 
-          const replacedValue = replaceValue(inputValue);
+        const replacedValue = replaceValue(inputValue);
 
-          const currentValue = event.currentTarget.value;
-          const start = event.currentTarget.selectionStart ?? 0;
-          const end = event.currentTarget.selectionEnd ?? 0;
+        const currentValue = event.currentTarget.value;
+        const start = event.currentTarget.selectionStart ?? 0;
+        const end = event.currentTarget.selectionEnd ?? 0;
 
-          event.currentTarget.value = `${currentValue.substring(0, start)}${replacedValue}${currentValue.substring(
-            end
-          )}`;
+        event.currentTarget.value = `${currentValue.substring(0, start)}${replacedValue}${currentValue.substring(
+          end
+        )}`.substring(0, maxLength);
 
-          event.currentTarget.selectionStart = start + replacedValue.length;
+        event.currentTarget.selectionStart = start + replacedValue.length;
 
-          event.currentTarget.selectionEnd = event.currentTarget.selectionStart;
+        event.currentTarget.selectionEnd = event.currentTarget.selectionStart;
 
+        event.preventDefault();
+
+        onValueChange?.(replacedValue);
+      }}
+      onFocus={() => onFocus?.()}
+      onBlur={() => onBlur?.()}
+      onKeyDown={event => {
+        if (!event.metaKey && !event.altKey && !event.ctrlKey && event.key.length === 1 && !isValidValue(event.key)) {
           event.preventDefault();
+        }
 
-          onValueChange?.(replacedValue);
-        }}
-        onFocus={() => onFocus?.()}
-        onBlur={() => onBlur?.()}
-        onKeyPress={event => {
-          if (!event.metaKey && !event.altKey && !event.ctrlKey && !isValidValue(event.key)) {
-            event.preventDefault();
-          }
-
-          onKeyPress?.({ key: event.key, prevent: event.preventDefault });
-        }}
-        onChange={event => onValueChange?.(event.target.value)}
-      />
-    )
+        onKeyDown?.({ key: event.key, prevent: () => event.preventDefault() });
+      }}
+      onChange={event => onValueChange?.(event.target.value)}
+      {...restProps}
+    />
   )
 );

--- a/packages/vibrant-components/src/lib/Input/InputProps.ts
+++ b/packages/vibrant-components/src/lib/Input/InputProps.ts
@@ -1,12 +1,18 @@
+import type { RefObject } from 'react';
 import { propVariant, withVariation } from '@vibrant-ui/core';
 
-type InputProps = {
+export type InputProps = {
+  ref?: RefObject<HTMLInputElement>;
   allowPattern?: RegExp;
-  placeholder?: string;
   defaultValue?: string;
+  placeholder?: string;
+  maxLength?: number;
+  disabled?: boolean;
+  readOnly?: boolean;
+  tabIndex?: number;
   onFocus?: () => void;
   onBlur?: () => void;
-  onKeyPress?: (_: { key: string; prevent: () => void }) => void;
+  onKeyDown?: (_: { key: string; prevent: () => void }) => void;
   onValueChange?: (_: string) => void;
 };
 

--- a/packages/vibrant-components/src/lib/Input/index.ts
+++ b/packages/vibrant-components/src/lib/Input/index.ts
@@ -1,0 +1,2 @@
+export type { InputProps } from './InputProps';
+export { Input } from './Input';


### PR DESCRIPTION
- Backspace 키를 입력하면 keyPress 이벤트가 트리거 되지 않는 문제가 있어서 KeyPress 이벤트를 KeyDown으로 변경했습니다
- disabled, readonly, maxLength, tabIndex prop을 추가했습니다.