### PR TITLE
fix(vibrant-components): onPaste 이벤트에서 onValueChange가 기존에 입력되어 있던 값을 포함해서 호출되게 수정한다

### DIFF
--- a/packages/vibrant-components/src/lib/Input/Input.tsx
+++ b/packages/vibrant-components/src/lib/Input/Input.tsx
@@ -35,9 +35,11 @@ export const Input = withInputVariation(
         const start = event.currentTarget.selectionStart ?? 0;
         const end = event.currentTarget.selectionEnd ?? 0;
 
-        event.currentTarget.value = `${currentValue.substring(0, start)}${replacedValue}${currentValue.substring(
-          end
-        )}`.substring(0, maxLength);
+        event.currentTarget.value = (
+          currentValue.substring(0, start) +
+          replacedValue +
+          currentValue.substring(end)
+        ).substring(0, maxLength);
 
         event.currentTarget.selectionStart = start + replacedValue.length;
 
@@ -45,7 +47,7 @@ export const Input = withInputVariation(
 
         event.preventDefault();
 
-        onValueChange?.(replacedValue);
+        onValueChange?.(event.currentTarget.value);
       }}
       onFocus={() => onFocus?.()}
       onBlur={() => onBlur?.()}


### PR DESCRIPTION
- 붙여넣기된 값으로 onValueChange 이벤트가 호출되는 문제가 있어서 실제 input에 입력된 값을 가져와서 호출하도록 수정했습니다.