### PR TITLE
fix(vibrant-components): inlineLabel이 false 일 때도 라벨이 inline으로 보이는 문제를 해결한다

### DIFF
--- a/packages/vibrant-components/src/lib/SelectField/SelectField.tsx
+++ b/packages/vibrant-components/src/lib/SelectField/SelectField.tsx
@@ -177,10 +177,10 @@ export const SelectField = withSelectFieldVariation(
               wordWrap="break-word"
             >
               {selectedOption ? (
-                <Box as="span" {...(inlineLabel ? { lineLimit: 1 } : {})}>
+                <Box as="span" lineLimit={inlineLabel ? 1 : undefined}>
                   {label && (
                     <>
-                      <Body level={2} color={labelColor} {...(inlineLabel ? {} : { lineLimit: 1 })}>
+                      <Body level={2} color={labelColor} lineLimit={inlineLabel ? undefined : 1}>
                         {label}
                       </Body>
                       {inlineLabel && (
@@ -190,7 +190,7 @@ export const SelectField = withSelectFieldVariation(
                       )}
                     </>
                   )}
-                  <Body level={2} color={disabled ? 'onView3' : 'onView1'} {...(inlineLabel ? {} : { lineLimit: 1 })}>
+                  <Body level={2} color={disabled ? 'onView3' : 'onView1'} lineLimit={inlineLabel ? undefined : 1}>
                     {selectedOption.label}
                   </Body>
                 </Box>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/33626219/180044929-df00b2e3-3135-4a65-8e10-8eec924fa08a.png)
