### PR TITLE
fix: withVariation에서 ref와 children 타입이 잘못 설정되는 문제를 수정한다

### DIFF
--- a/packages/vibrant-core/src/lib/Box/BoxProps.ts
+++ b/packages/vibrant-core/src/lib/Box/BoxProps.ts
@@ -16,7 +16,6 @@ export type BoxProps<
     base?: BaseComponent;
     id?: string;
     ref?: Ref<BaseComponent extends abstract new (...args: any) => any ? InstanceType<BaseComponent> : HTMLElement>;
-    children?: ReactNode;
   };
 
 export const shouldForwardProp = createShouldForwardProp(systemPropNames);

--- a/packages/vibrant-core/src/lib/withVariation/withVariation.tsx
+++ b/packages/vibrant-core/src/lib/withVariation/withVariation.tsx
@@ -1,9 +1,9 @@
-import type { FC, ForwardRefExoticComponent, PropsWithoutRef, RefAttributes, RefObject } from 'react';
+import type { FC, ForwardRefExoticComponent, PropsWithoutRef, Ref, RefAttributes } from 'react';
 import { forwardRef } from 'react';
 import type { VariantFn } from '../propVariant';
 
 type PickRefElement<Props, DefaultElement = HTMLElement> = Props extends {
-  ref?: RefObject<infer Element>;
+  ref?: Ref<infer Element>;
 }
   ? Element
   : DefaultElement;
@@ -12,7 +12,9 @@ type ComponentWithRef<Props, DefaultElement = HTMLElement> = ForwardRefExoticCom
   PropsWithoutRef<Props> & RefAttributes<PickRefElement<Props, DefaultElement>>
 >;
 
-type WithInnerRef<Props> = Props extends { ref?: infer Ref } ? Omit<Props, 'ref'> & { innerRef?: Ref } : Props;
+type WithInnerRef<Props> = Props extends { ref?: infer RefValue }
+  ? Omit<Props, 'ref'> & { innerRef?: RefValue }
+  : Props;
 
 type ComponentWithInnerRef<Props> = FC<WithInnerRef<Props>>;
 


### PR DESCRIPTION
- BaseComponent children 타입이 우선되도록 수정했습니다
- innerRef타입이 잘못 설정되는 문제를 수정했습니다