### PR TITLE
feat(vibrant-core): add ReactElementChild type

### DIFF
--- a/packages/vibrant-core/src/index.ts
+++ b/packages/vibrant-core/src/index.ts
@@ -1,6 +1,6 @@
 export { Box } from './lib/Box';
 export type { BoxProps } from './lib/Box';
-export type { ResponsiveValue } from './lib/types';
+export type { ReactElementChild, ResponsiveValue } from './lib/types';
 export type {
   BackgroundProps,
   BorderProps,

--- a/packages/vibrant-core/src/lib/types/ReactElementChild.ts
+++ b/packages/vibrant-core/src/lib/types/ReactElementChild.ts
@@ -1,0 +1,3 @@
+import type { ReactElement } from 'react';
+
+export type ReactElementChild = ReactElement | false | null | undefined;

--- a/packages/vibrant-core/src/lib/types/index.ts
+++ b/packages/vibrant-core/src/lib/types/index.ts
@@ -1,1 +1,2 @@
+export type { ReactElementChild } from './ReactElementChild';
 export type { ResponsiveValue } from './ResponsiveValue';


### PR DESCRIPTION
- children 타입에서 사용할 ReactElementChild 타입을 추가했습니다.