### PR TITLE
fix(vibrant-components): fix SelectOptionItem flex-shrink value to 0

### DIFF
--- a/packages/vibrant-components/src/lib/SelectOptionItem/SelectOptionItem.tsx
+++ b/packages/vibrant-components/src/lib/SelectOptionItem/SelectOptionItem.tsx
@@ -14,6 +14,7 @@ export const SelectOptionItem = withSelectOptionItemVariation(({ onClick, childr
     overlayColor="onView1"
     interactions={['hover', 'active']}
     onClick={onClick}
+    flexShrink={0}
     {...restProps}
   >
     <Body level={2}>{children}</Body>


### PR DESCRIPTION
- SelectField 컴포넌트에서 SelectOptionItem 높이가 작아지는 문제를 해결했습니다.