### PR TITLE
fix: Tab 컴포넌트의 flex-basis를 수정한다

### DIFF
--- a/packages/vibrant-components/src/lib/Tab/Tab.tsx
+++ b/packages/vibrant-components/src/lib/Tab/Tab.tsx
@@ -12,6 +12,7 @@ export const Tab = withTabVariation(
       ref={innerRef}
       flexShrink={0}
       flexGrow={1}
+      flexBasis="auto"
       flexDirection="row"
       display="inline-flex"
       borderBottomWidth={2}

--- a/packages/vibrant-components/src/lib/Tab/__snapshots__/Tab.spec.tsx.snap
+++ b/packages/vibrant-components/src/lib/Tab/__snapshots__/Tab.spec.tsx.snap
@@ -23,6 +23,9 @@ exports[`<Tab /> when Tab rendered match snapshot 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   border-bottom-width: 2px;
   border-bottom-style: solid;
   border-bottom-color: rgba(0, 0, 0, 0);

--- a/packages/vibrant-components/src/lib/TabGroup/__snapshots__/TabGroup.spec.tsx.snap
+++ b/packages/vibrant-components/src/lib/TabGroup/__snapshots__/TabGroup.spec.tsx.snap
@@ -104,6 +104,9 @@ exports[`<TabGroup /> when TabGroup rendered match snapshot 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   border-bottom-width: 2px;
   border-bottom-style: solid;
   border-bottom-color: #101010;
@@ -172,6 +175,9 @@ exports[`<TabGroup /> when TabGroup rendered match snapshot 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   border-bottom-width: 2px;
   border-bottom-style: solid;
   border-bottom-color: rgba(0, 0, 0, 0);
@@ -264,6 +270,9 @@ exports[`<TabGroup /> when TabGroup rendered match snapshot 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   border-bottom-width: 2px;
   border-bottom-style: solid;
   border-bottom-color: rgba(0, 0, 0, 0);


### PR DESCRIPTION
<img width="858" alt="image" src="https://user-images.githubusercontent.com/32216112/181685281-cd3382a0-9547-41cd-8249-7cfc735f4494.png">
