### PR TITLE
fix(eslint): _id와 __typename eslint rule을 비활성화합니다

### DIFF
--- a/packages/utils-eslint-config/src/rules/typescript.js
+++ b/packages/utils-eslint-config/src/rules/typescript.js
@@ -109,6 +109,13 @@ const typescriptRules = {
       format: ['StrictPascalCase'],
     },
 
+    // _id와 __typename은 허용된다
+    {
+      selector: ['typeProperty', 'objectLiteralProperty', 'classProperty'],
+      format: null,
+      filter: { regex: '^(_id|__typename)$', match: true },
+    },
+
     // __html은 허용된다
     {
       selector: ['objectLiteralProperty'],


### PR DESCRIPTION
몽고디비에서 주로 사용하는 _id와 grahpql에서 사용하는 __typename은 naming convention 예외로 추가합니다.