### PR TITLE
fix(vibrant-core): remove box 'as' prop default value

### DIFF
--- a/packages/vibrant-components/src/lib/OperatorButton/OperatorButton.tsx
+++ b/packages/vibrant-components/src/lib/OperatorButton/OperatorButton.tsx
@@ -3,14 +3,15 @@ import { Pressable } from '../Pressable';
 import { withOperationButtonVariation } from './OperatorButtonProps';
 
 export const OperatorButton = withOperationButtonVariation(
-  ({ IconComponent, backgroundColor, pressableProps, iconFill, ...restProps }) => (
+  ({ IconComponent, backgroundColor, iconFill, ...restProps }) => (
     <Box
       base={Pressable}
       p={7}
       borderWidth={0}
       borderRadius={2}
       backgroundColor={backgroundColor}
-      {...pressableProps}
+      overlayColor="onView1"
+      interactions={['hover', 'focus', 'active']}
       {...restProps}
     >
       <IconComponent size={16} fill={iconFill} />

--- a/packages/vibrant-components/src/lib/OperatorButton/OperatorButtonProps.ts
+++ b/packages/vibrant-components/src/lib/OperatorButton/OperatorButtonProps.ts
@@ -19,12 +19,10 @@ export const withOperationButtonVariation = withVariation<OperatorButtonProps>('
     variants: {
       true: {
         backgroundColor: 'disable',
-        pressableProps: {},
         iconFill: 'onView3',
       },
       false: {
         backgroundColor: 'surface1',
-        pressableProps: { overlayColor: 'onView1', interactions: ['hover', 'focus', 'active'] },
         iconFill: 'onView1',
       },
     } as const,

--- a/packages/vibrant-core/src/lib/Box/Box.tsx
+++ b/packages/vibrant-core/src/lib/Box/Box.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType, FC, ReactElement } from 'react';
-import { forwardRef } from 'react';
+import { createElement, forwardRef } from 'react';
 import styled from '@emotion/styled';
 import { createInterpolation } from '../createInterpolation';
 import { systemProps } from '../props';
@@ -9,10 +9,17 @@ import { shouldForwardProp } from './BoxProps';
 const interpolation = createInterpolation(systemProps, { display: 'flex' });
 
 export const Box = styled(
-  forwardRef<HTMLDivElement, BoxProps>(({ as = 'div', base, ...restProps }, ref) => {
-    const Component = base ? (base as ComponentType<any>) : as;
+  forwardRef<HTMLDivElement, BoxProps>(({ as, base, ...restProps }, ref) => {
+    const Component = base ? (base as ComponentType<any>) : undefined;
 
-    return <Component ref={ref} {...(base ? { as } : {})} {...restProps} />;
+    if (Component) {
+      return <Component ref={ref} {...(base ? { as } : {})} {...restProps} />;
+    }
+
+    return createElement(as ?? 'div', {
+      ref,
+      ...restProps,
+    });
   }),
   {
     shouldForwardProp,


### PR DESCRIPTION
### Before
<img width="304" alt="스크린샷 2022-08-02 오후 8 16 54" src="https://user-images.githubusercontent.com/33626219/182362226-a5b66098-b848-4255-9653-3a79be113a7b.png">
<img width="550" alt="스크린샷 2022-08-02 오후 8 17 03" src="https://user-images.githubusercontent.com/33626219/182362239-99b7a76d-665a-4736-831b-09cc34921f02.png">

### After
<img width="407" alt="스크린샷 2022-08-02 오후 8 17 28" src="https://user-images.githubusercontent.com/33626219/182362245-73ffa143-1a6f-463e-b7b7-80acce82b3f3.png">

