### PR TITLE
fix(vibrant-core): fix Svg component type error

### DIFF
--- a/packages/vibrant-core/src/lib/Svg/Svg.tsx
+++ b/packages/vibrant-core/src/lib/Svg/Svg.tsx
@@ -1,44 +1,53 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import type { FC } from 'react';
 import { Box } from '../Box';
-import type { BaseSvgProps, SvgProps } from './SvgProps';
+import type {
+  ClipPathProps,
+  DefsProps,
+  GProps,
+  LinearGradientProps,
+  MaskProps,
+  PathProps,
+  StopProps,
+  SvgProps,
+} from './SvgProps';
 
-const Path: FC<BaseSvgProps> = props => <Box as="path" {...props} />;
+const ClipPath: FC<ClipPathProps> = props => <Box as="clipPath" {...props} />;
 
-const Mask: FC<BaseSvgProps> = props => <Box as="mask" {...props} />;
+const Defs: FC<DefsProps> = props => <Box as="defs" {...props} />;
 
-const G: FC<BaseSvgProps> = props => <Box as="g" {...props} />;
+const G: FC<GProps> = props => <Box as="g" {...props} />;
 
-const Defs: FC<BaseSvgProps> = props => <Box as="defs" {...props} />;
+const LinearGradient: FC<LinearGradientProps> = props => <Box as="linearGradient" {...props} />;
 
-const ClipPath: FC<BaseSvgProps> = props => <Box as="clipPath" {...props} />;
+const Mask: FC<MaskProps> = props => <Box as="mask" {...props} />;
 
-const LinearGradient: FC<BaseSvgProps> = props => <Box as="linearGradient" {...props} />;
+const Path: FC<PathProps> = props => <Box as="path" {...props} />;
 
-const Stop: FC<BaseSvgProps> = props => <Box as="stop" {...props} />;
+const Stop: FC<StopProps> = props => <Box as="stop" {...props} />;
 
 export const Svg: FC<SvgProps> & {
-  G: FC<BaseSvgProps>;
-  Mask: FC<BaseSvgProps>;
-  Path: FC<BaseSvgProps>;
-  Defs: FC<BaseSvgProps>;
-  ClipPath: FC<BaseSvgProps>;
-  LinearGradient: FC<BaseSvgProps>;
-  Stop: FC<BaseSvgProps>;
+  ClipPath: FC<ClipPathProps>;
+  Defs: FC<DefsProps>;
+  G: FC<GProps>;
+  LinearGradient: FC<LinearGradientProps>;
+  Mask: FC<MaskProps>;
+  Path: FC<PathProps>;
+  Stop: FC<StopProps>;
 } = ({ width, height, ...restProps }) => (
-  <Box as="svg" display="inline-flex" width={width || 'auto'} height={height || 'auto'} {...restProps} />
+  <Box as="svg" display="inline-flex" width={width || 'auto'} height={height || 'auto'} {...restProps}></Box>
 );
-
-Svg.Mask = Mask;
-
-Svg.G = G;
-
-Svg.Path = Path;
-
-Svg.Defs = Defs;
 
 Svg.ClipPath = ClipPath;
 
+Svg.Defs = Defs;
+
+Svg.G = G;
+
 Svg.LinearGradient = LinearGradient;
+
+Svg.Mask = Mask;
+
+Svg.Path = Path;
 
 Svg.Stop = Stop;

--- a/packages/vibrant-core/src/lib/Svg/SvgProps.ts
+++ b/packages/vibrant-core/src/lib/Svg/SvgProps.ts
@@ -1,10 +1,21 @@
-import type { SVGProps } from 'react';
 import type { BoxProps } from '../Box';
 
-export type BaseSvgProps = Omit<
-  SVGProps<SVGElement>,
-  keyof BoxProps<undefined, 'clipPath' | 'defs' | 'g' | 'linearGradient' | 'mark' | 'path' | 'stop' | 'svg'>
-> & { fill?: string; id?: string };
+export type ClipPathProps = BoxProps<undefined, 'clipPath'>;
 
-export type SvgProps = Omit<BaseSvgProps, 'fill'> &
-  Pick<BoxProps, 'children' | 'fill' | 'height' | 'id' | 'opacity' | 'width'>;
+export type DefsProps = BoxProps<undefined, 'defs'>;
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type GProps = BoxProps<undefined, 'g'>;
+
+export type LinearGradientProps = BoxProps<undefined, 'linearGradient'>;
+
+export type MaskProps = BoxProps<undefined, 'mask'>;
+
+export type PathProps = BoxProps<undefined, 'path'>;
+
+export type StopProps = BoxProps<undefined, 'stop'>;
+
+export type SvgProps = Pick<
+  BoxProps<undefined, 'svg'>,
+  keyof JSX.IntrinsicElements['svg'] | 'children' | 'fill' | 'height' | 'id' | 'width'
+>;


### PR DESCRIPTION
- Svg 관련 컴포넌트들이 BoxProps를 사용하도록 수정했습니다.