### PR TITLE
fix: react-spring을 ExternalDependency에서 주입받도록 한다

### DIFF
--- a/.storybook/decorators/withVibrantProvider.tsx
+++ b/.storybook/decorators/withVibrantProvider.tsx
@@ -1,0 +1,13 @@
+import * as ReactSpring from '@react-spring/web';
+import type { DecoratorFn } from '@storybook/react';
+import { VibrantProvider } from '@vibrant-ui/core';
+
+export const withVibrantProvider: DecoratorFn = storyFn => (
+  <VibrantProvider
+    dependencies={{
+      reactSpringModule: ReactSpring,
+    }}
+  >
+    {storyFn()}
+  </VibrantProvider>
+);

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -6,6 +6,7 @@ import { withAppetize } from './decorators/withAppetize';
 import { withGlobalEvent } from './decorators/withGlobalEvent';
 import { withGlobalStyle } from './decorators/withGlobalStyle';
 import { withTheme } from './decorators/withTheme';
+import { withVibrantProvider } from './decorators/withVibrantProvider';
 
 export const parameters: Parameters = {
   layout: 'fullscreen',
@@ -46,4 +47,11 @@ export const globalTypes: GlobalTypes = {
   },
 };
 
-export const decorators: DecoratorFn[] = [withGlobalStyle, withTheme, withGlobalEvent, withAppetize, DeviceDecorator];
+export const decorators: DecoratorFn[] = [
+  withVibrantProvider,
+  withGlobalStyle,
+  withTheme,
+  withGlobalEvent,
+  withAppetize,
+  DeviceDecorator,
+];

--- a/packages/vibrant-core/src/index.ts
+++ b/packages/vibrant-core/src/index.ts
@@ -29,6 +29,8 @@ export { propVariant } from './lib/propVariant';
 export { withVariation } from './lib/withVariation';
 export { ThemeProvider, useCurrentTheme } from './lib/ThemeProvider';
 export { OnColorContainer } from './lib/OnColorContainer';
+export type { Dependencies } from './lib/DependencyProvider';
+export { DependencyProvider, useDependency } from './lib/DependencyProvider';
 export type { SystemPropThemeScale } from './lib/createSystemProp';
 export { useResponsiveValue } from './lib/useResponsiveValue';
 export { VibrantProvider } from './lib/VibrantProvider';

--- a/packages/vibrant-core/src/lib/DependencyProvider/DependencyProvider.tsx
+++ b/packages/vibrant-core/src/lib/DependencyProvider/DependencyProvider.tsx
@@ -2,7 +2,7 @@ import type { ComponentType, FC } from 'react';
 import { createContext, useContext } from 'react';
 import type { ReactElementChild } from '../../types';
 
-type Dependencies = {
+export type Dependencies = {
   nativeLinearGradient?: ComponentType<{
     colors: any;
     locations?: any;
@@ -16,6 +16,7 @@ type Dependencies = {
       offset?: any;
     }[];
   }>;
+  reactSpringModule?: any;
 };
 
 export type ExternalComponentName = keyof Dependencies;

--- a/packages/vibrant-core/src/lib/DependencyProvider/index.ts
+++ b/packages/vibrant-core/src/lib/DependencyProvider/index.ts
@@ -1,2 +1,2 @@
-export type { ExternalComponentName, DependencyProviderProps } from './DependencyProvider';
+export type { ExternalComponentName, DependencyProviderProps, Dependencies } from './DependencyProvider';
 export { DependencyProvider, useDependency } from './DependencyProvider';

--- a/packages/vibrant-example-app/src/app/App.tsx
+++ b/packages/vibrant-example-app/src/app/App.tsx
@@ -1,14 +1,17 @@
 import { useFonts } from 'expo-font';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Shadow } from 'react-native-shadow-2';
+import * as ReactSpring from '@react-spring/native';
 import { VStack, createShadowsComponent } from '@vibrant-ui/components';
+import type { Dependencies } from '@vibrant-ui/core';
 import { VibrantProvider } from '@vibrant-ui/core';
 import { StoryView } from './StoryView';
 import { useStorybookInformation } from './useStorybookInformation';
 
-const dependencies = {
+const dependencies: Dependencies = {
   nativeLinearGradient: LinearGradient,
   nativeShadows: createShadowsComponent(Shadow),
+  reactSpringModule: ReactSpring,
 };
 
 const App = () => {

--- a/packages/vibrant-motion/package.json
+++ b/packages/vibrant-motion/package.json
@@ -1,4 +1,18 @@
 {
   "name": "@vibrant-ui/motion",
-  "version": "0.3.7"
+  "version": "0.3.7",
+  "private": false,
+  "sideEffects": false,
+  "peerDependencies": {
+    "@types/react": "^17.0.0 || ^18.0.0",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-spring": "^9.0.0"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  }
 }

--- a/packages/vibrant-motion/src/lib/Motion/Motion.tsx
+++ b/packages/vibrant-motion/src/lib/Motion/Motion.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useImperativeHandle, useMemo } from 'react';
 import { useResponsiveValue } from '@vibrant-ui/core';
-import { animated, useSpring } from '../external/ReactSpring';
+import { useReactSpring } from '../useReactSpring';
 import { withTransformStyle } from '../withTransformStyle';
 import { withMotionVariation } from './MotionProps';
 
 export const Motion = withMotionVariation(({ innerRef, children, duration, loop, from, to }) => {
+  const { animated, useSpring } = useReactSpring();
+
   const AnimatedComponent = useMemo(
     () => (typeof children.type === 'string' ? animated[children.type as 'div'] : animated(children.type)),
-    [children.type]
+    [animated, children.type]
   );
   const { getResponsiveValue } = useResponsiveValue();
 

--- a/packages/vibrant-motion/src/lib/Transition/Transition.tsx
+++ b/packages/vibrant-motion/src/lib/Transition/Transition.tsx
@@ -1,14 +1,16 @@
 import { useEffect, useMemo } from 'react';
 import { useResponsiveValue } from '@vibrant-ui/core';
-import { animated, useSpring } from '../external/ReactSpring';
+import { useReactSpring } from '../useReactSpring';
 import { withTransformStyle } from '../withTransformStyle';
 import { withTransitionVariation } from './TransitionProp';
 
 export const Transition = withTransitionVariation(
   ({ innerRef, children, style, animation, duration, ...restProps }) => {
+    const { animated, useSpring } = useReactSpring();
+
     const AnimatedComponent = useMemo(
       () => (typeof children.type === 'string' ? animated[children.type as 'div'] : animated(children.type)),
-      [children.type]
+      [animated, children.type]
     );
     const { getResponsiveValue } = useResponsiveValue();
 

--- a/packages/vibrant-motion/src/lib/external/ReactSpring/ReactSpring.native.ts
+++ b/packages/vibrant-motion/src/lib/external/ReactSpring/ReactSpring.native.ts
@@ -1,1 +1,0 @@
-export * from '@react-spring/native';

--- a/packages/vibrant-motion/src/lib/external/ReactSpring/ReactSpring.ts
+++ b/packages/vibrant-motion/src/lib/external/ReactSpring/ReactSpring.ts
@@ -1,1 +1,0 @@
-export * from '@react-spring/web';

--- a/packages/vibrant-motion/src/lib/external/ReactSpring/index.ts
+++ b/packages/vibrant-motion/src/lib/external/ReactSpring/index.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line import/export
-export * from './ReactSpring';

--- a/packages/vibrant-motion/src/lib/useReactSpring/__mocks__/useReactSpring.ts
+++ b/packages/vibrant-motion/src/lib/useReactSpring/__mocks__/useReactSpring.ts
@@ -1,0 +1,3 @@
+import * as ReactSpringModule from 'react-spring';
+
+export const useReactSpring = (): typeof ReactSpringModule => ReactSpringModule;

--- a/packages/vibrant-motion/src/lib/useReactSpring/index.ts
+++ b/packages/vibrant-motion/src/lib/useReactSpring/index.ts
@@ -1,0 +1,1 @@
+export { useReactSpring } from './useReactSpring';

--- a/packages/vibrant-motion/src/lib/useReactSpring/useReactSpring.ts
+++ b/packages/vibrant-motion/src/lib/useReactSpring/useReactSpring.ts
@@ -1,0 +1,15 @@
+import type * as ReactSpringModule from 'react-spring';
+import { useDependency } from '@vibrant-ui/core';
+
+export const useReactSpring = (): typeof ReactSpringModule => {
+  const {
+    dependencies: { reactSpringModule },
+  } = useDependency();
+  const module = reactSpringModule;
+
+  if (!module) {
+    throw new Error('ReactSpring dependency not provided');
+  }
+
+  return module;
+};

--- a/packages/vibrant-utils/src/lib/test/createReactNativeRenderer/createReactNativeRenderer.tsx
+++ b/packages/vibrant-utils/src/lib/test/createReactNativeRenderer/createReactNativeRenderer.tsx
@@ -22,10 +22,12 @@ export const createReactNativeRenderer = () => {
     });
   });
 
+  const wrap = (global as any).wrap ?? ((component: any) => component);
+
   return {
     render: (element: ReactElement): ReactNativeRenderer =>
-      render(<EmotionCacheProvider value={emotionCache}>{element}</EmotionCacheProvider>),
+      render(<EmotionCacheProvider value={emotionCache}>{wrap(element)}</EmotionCacheProvider>),
     rerender: (renderer: ReactNativeRenderer, element: ReactElement) =>
-      renderer.rerender(<EmotionCacheProvider value={emotionCache}>{element}</EmotionCacheProvider>),
+      renderer.rerender(<EmotionCacheProvider value={emotionCache}>{wrap(element)}</EmotionCacheProvider>),
   };
 };

--- a/packages/vibrant-utils/src/lib/test/createReactRenderer/createReactRenderer.tsx
+++ b/packages/vibrant-utils/src/lib/test/createReactRenderer/createReactRenderer.tsx
@@ -22,10 +22,12 @@ export const createReactRenderer = () => {
     });
   });
 
+  const wrap = (global as any).wrap ?? ((component: any) => component);
+
   return {
     render: (element: ReactElement): ReactRenderer =>
-      render(<EmotionCacheProvider value={emotionCache}>{element}</EmotionCacheProvider>),
+      render(<EmotionCacheProvider value={emotionCache}>{wrap(element)}</EmotionCacheProvider>),
     rerender: (renderer: ReactRenderer, element: ReactElement) =>
-      renderer.rerender(<EmotionCacheProvider value={emotionCache}>{element}</EmotionCacheProvider>),
+      renderer.rerender(<EmotionCacheProvider value={emotionCache}>{wrap(element)}</EmotionCacheProvider>),
   };
 };

--- a/tools/jest-setup.js
+++ b/tools/jest-setup.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-undef */
+import { VibrantProvider } from '../packages/vibrant-core/src';
+
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: jest.fn().mockImplementation(query => ({
@@ -12,3 +14,7 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: jest.fn(),
   })),
 });
+
+global.wrap = children => (
+  <VibrantProvider dependencies={{ reactSpringModule: require('@react-spring/web') }}>{children}</VibrantProvider>
+);


### PR DESCRIPTION

- vibrant-ui/motion을 외부에서 import하면 react-spring 라이브러리를 플랫폼에 맞게 못찾아서 ExternalDependency로 라이브러를 분리했습니다
