### PR TITLE
feat(vibrant-components): visible Calendar on remain area

### DIFF
--- a/packages/vibrant-components/src/lib/DatePickerField/DatePickerField.stories.tsx
+++ b/packages/vibrant-components/src/lib/DatePickerField/DatePickerField.stories.tsx
@@ -1,13 +1,20 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import { Space } from '../Space';
+import { VStack } from '../VStack';
 import { DatePickerField } from './DatePickerField';
 
 export default {
   title: 'DatePickerField',
   component: DatePickerField,
   args: {
-    placeholder: '0000/00/00',
     label: '날짜 선택',
   },
 } as ComponentMeta<typeof DatePickerField>;
 
-export const Basic: ComponentStory<typeof DatePickerField> = props => <DatePickerField {...props} />;
+export const Basic: ComponentStory<typeof DatePickerField> = props => (
+  <VStack width="100%">
+    <Space height={450} />
+    <DatePickerField {...props} />
+    <Space height={450} />
+  </VStack>
+);

--- a/packages/vibrant-components/src/lib/DatePickerField/DatePickerField.tsx
+++ b/packages/vibrant-components/src/lib/DatePickerField/DatePickerField.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
-import { Box } from '@vibrant-ui/core';
+import { useEffect, useRef, useState } from 'react';
+import { Box, getElementPosition } from '@vibrant-ui/core';
+import type { TargetElement } from '@vibrant-ui/utils';
 import { getDateString, useSafeDeps } from '@vibrant-ui/utils';
 import { Calendar } from '../Calendar';
 import { DateInput } from '../DateInput';
@@ -12,6 +13,20 @@ export const DatePickerField = withDatePickerFieldVariation(
     const [isCalendarOpened, setIsCalendarOpened] = useState(false);
     const [inputValue, setInputValue] = useState(defaultValue ? getDateString(defaultValue) : '');
     const onValueChangeRef = useSafeDeps(onValueChange);
+    const inputRef = useRef<TargetElement>(null);
+    const [calendarPosition, setCalendarPosition] = useState('bottom');
+
+    const openCalendar = async () => {
+      if (!inputRef.current) {
+        return;
+      }
+
+      const { top, bottom } = await getElementPosition(inputRef.current);
+
+      setCalendarPosition(top > bottom ? 'top' : 'bottom');
+
+      setIsCalendarOpened(true);
+    };
 
     useEffect(() => {
       if (!defaultValue) {
@@ -36,8 +51,9 @@ export const DatePickerField = withDatePickerFieldVariation(
     return (
       <Box position="relative" width="100%" height={50}>
         <DateInput
+          ref={inputRef}
           value={inputValue}
-          onClick={() => setIsCalendarOpened(true)}
+          onClick={openCalendar}
           disabled={disabled}
           onClear={() => setValue(undefined)}
           placeholder={placeholder}
@@ -47,7 +63,12 @@ export const DatePickerField = withDatePickerFieldVariation(
           helperText={helperText}
         />
         <Dismissible active={isCalendarOpened} onDismiss={() => setIsCalendarOpened(false)}>
-          <Box position="absolute" top={56} left={0} hidden={!isCalendarOpened}>
+          <Box
+            position="absolute"
+            left={0}
+            hidden={!isCalendarOpened}
+            {...{ [calendarPosition === 'top' ? 'bottom' : 'top']: 56 }}
+          >
             <Calendar
               range={false}
               date={value}

--- a/packages/vibrant-components/src/lib/RangePickerField/RangePickerField.stories.tsx
+++ b/packages/vibrant-components/src/lib/RangePickerField/RangePickerField.stories.tsx
@@ -1,4 +1,6 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import { Space } from '../Space';
+import { VStack } from '../VStack';
 import { RangePickerField } from './RangePickerField';
 
 export default {
@@ -6,8 +8,13 @@ export default {
   component: RangePickerField,
   args: {
     label: '범위 선택',
-    placeholder: '0000/00/00 ~ 0000/00/00',
   },
 } as ComponentMeta<typeof RangePickerField>;
 
-export const Basic: ComponentStory<typeof RangePickerField> = props => <RangePickerField {...props} />;
+export const Basic: ComponentStory<typeof RangePickerField> = props => (
+  <VStack width="100%">
+    <Space height={450} />
+    <RangePickerField {...props} />
+    <Space height={450} />
+  </VStack>
+);

--- a/packages/vibrant-components/src/lib/RangePickerField/RangePickerField.tsx
+++ b/packages/vibrant-components/src/lib/RangePickerField/RangePickerField.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
-import { Box } from '@vibrant-ui/core';
+import { useEffect, useRef, useState } from 'react';
+import { Box, getElementPosition } from '@vibrant-ui/core';
+import type { TargetElement } from '@vibrant-ui/utils';
 import { getDateString, useSafeDeps } from '@vibrant-ui/utils';
 import { Calendar } from '../Calendar';
 import { DateInput } from '../DateInput';
@@ -16,6 +17,20 @@ export const RangePickerField = withRangePickerFieldVariation(
       defaultValue ? getRangeString(defaultValue.start, defaultValue.end) : ''
     );
     const onValueChangeRef = useSafeDeps(onValueChange);
+    const inputRef = useRef<TargetElement>(null);
+    const [calendarPosition, setCalendarPosition] = useState('bottom');
+
+    const openCalendar = async () => {
+      if (!inputRef.current) {
+        return;
+      }
+
+      const { top, bottom } = await getElementPosition(inputRef.current);
+
+      setCalendarPosition(top > bottom ? 'top' : 'bottom');
+
+      setIsCalendarOpened(true);
+    };
 
     const handleDismiss = () => {
       setIsCalendarOpened(false);
@@ -55,7 +70,7 @@ export const RangePickerField = withRangePickerFieldVariation(
       <Box position="relative" width="100%" height={50}>
         <DateInput
           value={inputValue}
-          onClick={() => setIsCalendarOpened(true)}
+          onClick={openCalendar}
           disabled={disabled}
           onClear={() => setValue(undefined)}
           placeholder={placeholder}
@@ -65,7 +80,13 @@ export const RangePickerField = withRangePickerFieldVariation(
           state={state}
         />
         <Dismissible active={isCalendarOpened} onDismiss={handleDismiss}>
-          <Box position="absolute" top={56} left={0} hidden={!isCalendarOpened}>
+          <Box
+            position="absolute"
+            top={56}
+            left={0}
+            hidden={!isCalendarOpened}
+            {...{ [calendarPosition === 'top' ? 'bottom' : 'top']: 56 }}
+          >
             <Calendar
               range={true}
               startDate={value?.start}

--- a/packages/vibrant-core/src/index.ts
+++ b/packages/vibrant-core/src/index.ts
@@ -34,3 +34,4 @@ export { useResponsiveValue } from './lib/useResponsiveValue';
 export { VibrantProvider } from './lib/VibrantProvider';
 export { useGlobalEvent, GlobalEventProvider } from './lib/GlobalEventProvider';
 export type { ClickEvent } from './lib/GlobalEventProvider';
+export { getElementPosition } from './lib/getElementPosition';

--- a/packages/vibrant-core/src/lib/getElementPosition/getElementPosition.native.ts
+++ b/packages/vibrant-core/src/lib/getElementPosition/getElementPosition.native.ts
@@ -1,0 +1,15 @@
+import { Dimensions } from 'react-native';
+import type { TargetElement } from '@vibrant-ui/utils';
+import { getElementRect } from '@vibrant-ui/utils';
+
+export const getElementPosition = async (ref: TargetElement) => {
+  const { x, y, width, height } = await getElementRect(ref);
+  const { width: screenWidth, height: screenHeight } = Dimensions.get('screen');
+
+  const top = y;
+  const left = x;
+  const bottom = screenHeight - (y + height);
+  const right = screenWidth - (x + width);
+
+  return { top, left, bottom, right, width, height };
+};

--- a/packages/vibrant-core/src/lib/getElementPosition/getElementPosition.ts
+++ b/packages/vibrant-core/src/lib/getElementPosition/getElementPosition.ts
@@ -1,0 +1,13 @@
+import type { TargetElement } from '@vibrant-ui/utils';
+import { getElementRect } from '@vibrant-ui/utils';
+
+export const getElementPosition = async (ref: TargetElement) => {
+  const { x, y, width, height } = await getElementRect(ref);
+
+  const top = y;
+  const left = x;
+  const bottom = window.innerHeight - (y + height);
+  const right = window.innerWidth - (x + width);
+
+  return { top, left, bottom, right, width, height };
+};

--- a/packages/vibrant-core/src/lib/getElementPosition/index.ts
+++ b/packages/vibrant-core/src/lib/getElementPosition/index.ts
@@ -1,0 +1,1 @@
+export { getElementPosition } from './getElementPosition';

--- a/packages/vibrant-utils/src/index.ts
+++ b/packages/vibrant-utils/src/index.ts
@@ -1,6 +1,7 @@
 export type { DeepPartial } from './lib/type/DeepPartial';
 export type { DeepWritable } from './lib/type/DeepWritable';
 export type { DistributiveOmit } from './lib/type/DistributiveOmit';
+export type { TargetElement, Rect } from './lib/getElementRect';
 export type { Path } from './lib/type/Path';
 export { isDefined } from './lib/isDefined';
 export { get } from './lib/get';

--- a/packages/vibrant-utils/src/lib/getElementRect/index.ts
+++ b/packages/vibrant-utils/src/lib/getElementRect/index.ts
@@ -1,1 +1,2 @@
 export { getElementRect } from './getElementRect';
+export type { Rect, TargetElement } from './type';


### PR DESCRIPTION
- vibrant-core에 getElementPosition을 추가했습니다
- DateField, RangeField에서 Calendar가 더 많은 공간에 표시되도록 했습니다

<img width="1169" alt="image" src="https://user-images.githubusercontent.com/32216112/184111209-04f47c27-4310-4069-8fbb-c250618b074d.png">
<img width="1162" alt="image" src="https://user-images.githubusercontent.com/32216112/184111229-de4b37e8-3859-42ea-868f-1e15066393e0.png">
