### PR TITLE
chore: 네이티브 프리뷰를 개선한다

### DIFF
--- a/packages/vibrant-example-app/src/app/App.tsx
+++ b/packages/vibrant-example-app/src/app/App.tsx
@@ -1,10 +1,12 @@
 import { useFonts } from 'expo-font';
 import { LinearGradient } from 'expo-linear-gradient';
+import React from 'react';
+import { SafeAreaView, ScrollView } from 'react-native';
 import { Shadow } from 'react-native-shadow-2';
 import * as ReactSpring from '@react-spring/native';
-import { VStack, createShadowsComponent } from '@vibrant-ui/components';
+import { createShadowsComponent } from '@vibrant-ui/components';
 import type { Dependencies } from '@vibrant-ui/core';
-import { VibrantProvider } from '@vibrant-ui/core';
+import { Box, VibrantProvider } from '@vibrant-ui/core';
 import { StoryView } from './StoryView';
 import { useStorybookInformation } from './useStorybookInformation';
 
@@ -27,9 +29,11 @@ const App = () => {
 
   return (
     <VibrantProvider dependencies={dependencies}>
-      <VStack alignment="center" justifyContent="center" height="100%" px={20}>
-        <StoryView {...story} />
-      </VStack>
+      <Box base={ScrollView} height="100%">
+        <Box base={SafeAreaView}>
+          <StoryView {...story} />
+        </Box>
+      </Box>
     </VibrantProvider>
   );
 };

--- a/packages/vibrant-example-app/src/app/useStorybookInformation.ts
+++ b/packages/vibrant-example-app/src/app/useStorybookInformation.ts
@@ -22,8 +22,12 @@ export const useStorybookInformation = () => {
   const [story, setStory] = useState<Story | null>(null);
 
   useEffect(() => {
+    if (story) {
+      return;
+    }
+
     Linking.getInitialURL().then(getStoryFromUrl).then(setStory);
-  }, []);
+  }, [story]);
 
   useEffect(() => {
     const listener = Linking.addEventListener('url', event => setStory(getStoryFromUrl(event.url)));


### PR DESCRIPTION
- 기본으로 스크롤뷰가 되도록 하였습니다.
- SafeArea가 적용되도록 하고 웹과 동일한 위치에 컴포넌트가 나오도록 했습니다
- App 코드르 수정할 때 딥링크가 초기 링크로 가지는 문제를 수정했습니다

<img width="1498" alt="image" src="https://user-images.githubusercontent.com/32216112/184119752-25ba906f-e435-4476-a2ae-46e6ecb2e90f.png">
