### PR TITLE
fix: react-spring 라이브러리가 Dependency에 기본 값으로 사용되도록 한다

### DIFF
--- a/packages/vibrant-core/src/lib/ConfigProvider/ConfigProvider.tsx
+++ b/packages/vibrant-core/src/lib/ConfigProvider/ConfigProvider.tsx
@@ -1,5 +1,6 @@
 import type { ComponentType, FC } from 'react';
 import { createContext, useContext, useMemo } from 'react';
+import * as ReactSpring from 'react-spring';
 import type { ReactElementChild } from '../../types';
 
 export type Dependencies = {
@@ -35,7 +36,9 @@ type ConfigContextValue = {
 };
 
 const ConfigContext = createContext<ConfigContextValue>({
-  dependencies: {},
+  dependencies: {
+    reactSpringModule: ReactSpring,
+  },
   translations: {
     calendar: {
       title: '{year}년 {month}',

--- a/tools/jest-setup.js
+++ b/tools/jest-setup.js
@@ -14,7 +14,3 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: jest.fn(),
   })),
 });
-
-global.wrap = children => (
-  <VibrantProvider dependencies={{ reactSpringModule: require('@react-spring/web') }}>{children}</VibrantProvider>
-);


### PR DESCRIPTION
- 무조건 VIbrantProivder에 라이브러러리 넣어야하는게 불편해서.. 안넣어도 동작되도록 했습니다
