### PR TITLE
chore(vibrant-core): export LayoutEvent type

### DIFF
--- a/packages/vibrant-core/src/index.ts
+++ b/packages/vibrant-core/src/index.ts
@@ -1,5 +1,5 @@
 export { Box } from './lib/Box';
-export type { BoxProps } from './lib/Box';
+export type { BoxProps, LayoutEvent } from './lib/Box';
 export { Svg } from './lib/Svg';
 export type { SvgProps } from './lib/Svg';
 export { Text } from './lib/Text';

--- a/packages/vibrant-core/src/lib/Box/BoxProps.ts
+++ b/packages/vibrant-core/src/lib/Box/BoxProps.ts
@@ -125,6 +125,8 @@ export type BoxProps<
     onLayout?: (layoutEvent: LayoutEvent) => void;
   };
 
+export type { LayoutEvent };
+
 export const interpolation = createInterpolation(systemProps, { display: 'flex', boxSizing: 'border-box' });
 
 export const shouldForwardProp = createShouldForwardProp(systemPropNames);

--- a/packages/vibrant-core/src/lib/Box/index.ts
+++ b/packages/vibrant-core/src/lib/Box/index.ts
@@ -1,2 +1,2 @@
-export type { BoxProps } from './BoxProps';
+export type { BoxProps, LayoutEvent } from './BoxProps';
 export { Box } from './Box';


### PR DESCRIPTION
onLayoutEvent를 커스텀하였는데 타입을 export하지 않아 사용에 불편함이 있어서 .. 타입을 export 하도록 수정했습니다.