### PR TITLE
fix(vibrant-motion): interpolate Transition from style

### DIFF
--- a/packages/vibrant-motion/src/lib/Transition/Transition.tsx
+++ b/packages/vibrant-motion/src/lib/Transition/Transition.tsx
@@ -43,7 +43,7 @@ export const Transition = withTransitionVariation(
       [currentStyle, duration, easing, interpolation, onEnd, onStart]
     );
 
-    const [styles, springApi] = useSpring(() => ({ from: animation }));
+    const [styles, springApi] = useSpring(() => ({ from: interpolation(animation) }));
 
     useEffect(() => {
       springApi.start(option);


### PR DESCRIPTION
### Before
<img width="288" alt="스크린샷 2022-08-24 오후 2 02 58" src="https://user-images.githubusercontent.com/33626219/186333154-ef4d39a8-ab04-4631-a8c9-5dbd6fab6ceb.png">

### After
<img width="285" alt="스크린샷 2022-08-24 오후 2 03 15" src="https://user-images.githubusercontent.com/33626219/186333157-42cd8c45-2fef-4fa2-bd95-9933e2571f8f.png">
