### PR TITLE
fix(vibrant-core): remove ref and children prop when use base prop

### DIFF
--- a/packages/vibrant-core/src/lib/Box/Box.tsx
+++ b/packages/vibrant-core/src/lib/Box/Box.tsx
@@ -39,7 +39,7 @@ export const Box = styled(
     shouldForwardProp,
   }
 )(interpolation) as <
-  BaseComponent extends ComponentType<any> | undefined = undefined,
+  BaseComponent extends ComponentType | undefined = undefined,
   ElementName extends BoxElements | undefined = undefined
 >(
   props: BoxProps<BaseComponent, ElementName>

--- a/packages/vibrant-core/src/lib/Box/BoxProps.ts
+++ b/packages/vibrant-core/src/lib/Box/BoxProps.ts
@@ -110,22 +110,22 @@ export type BoxElements =
 export type BoxProps<
   BaseComponent extends ComponentType | undefined = undefined,
   ElementName extends BoxElements | undefined = undefined
-> = DistributiveOmit<
-  BaseComponent extends ComponentType<infer BaseComponentProps>
-    ? BaseComponentProps
-    : ElementName extends keyof JSX.IntrinsicElements
-    ? JSX.IntrinsicElements[ElementName]
-    : Record<never, never>,
-  keyof SystemProps
-> &
-  SystemProps & {
-    as?: ElementName;
-    base?: BaseComponent;
-    id?: string;
-    ref?: Ref<BaseComponent extends abstract new (...args: any) => any ? InstanceType<BaseComponent> : HTMLElement>;
-    children?: ReactElementChild | ReactElementChild[];
-    onLayout?: (layoutEvent: LayoutEvent) => void;
-  };
+> = SystemProps & {
+  as?: ElementName;
+  base?: BaseComponent;
+  id?: string;
+  onLayout?: (layoutEvent: LayoutEvent) => void;
+} & DistributiveOmit<
+    BaseComponent extends ComponentType<infer BaseComponentProps>
+      ? BaseComponentProps
+      : (ElementName extends keyof JSX.IntrinsicElements
+          ? JSX.IntrinsicElements[ElementName]
+          : Record<never, never>) & {
+          ref?: Ref<HTMLElement>;
+          children?: ReactElementChild | ReactElementChild[];
+        },
+    keyof SystemProps
+  >;
 
 export type { LayoutEvent };
 

--- a/packages/vibrant-core/src/lib/Svg/SvgProps.ts
+++ b/packages/vibrant-core/src/lib/Svg/SvgProps.ts
@@ -1,33 +1,49 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import type { FC } from 'react';
-import type {
-  ClipPath as RNClipPath,
-  Defs as RNDefs,
-  G as RNG,
-  LinearGradient as RNLinearGradient,
-  Mask as RNMask,
-  Path as RNPath,
-  Stop as RNStop,
-  Svg as RNSvg,
-} from 'react-native-svg';
-import type { BoxProps } from '../Box';
-import type { SystemProps } from '../Box/BoxProps';
+import type { ReactElementChild } from '../../types';
+import type { SizingSystemProps, SvgSystemProps } from '../props';
 
-export type ClipPathProps = Omit<BoxProps<typeof RNClipPath>, 'ref'>;
+export type ClipPathProps = {
+  id?: string;
+  children?: ReactElementChild | ReactElementChild[];
+};
 
-export type DefsProps = Omit<BoxProps<typeof RNDefs>, 'ref'>;
+export type DefsProps = {
+  id?: string;
+  children?: ReactElementChild | ReactElementChild[];
+};
 
-export type GProps = Omit<BoxProps<typeof RNG>, 'ref'>;
+export type GProps = {
+  clipPath?: string;
+  children?: ReactElementChild | ReactElementChild[];
+};
 
-export type LinearGradientProps = Omit<BoxProps<typeof RNLinearGradient>, 'ref'>;
+export type LinearGradientProps = {
+  gradientTransform?: string;
+};
 
-export type MaskProps = Omit<BoxProps<typeof RNMask>, 'ref'>;
+export type MaskProps = {
+  id?: string;
+  children?: ReactElementChild | ReactElementChild[];
+};
 
-export type PathProps = Omit<BoxProps<typeof RNPath>, 'ref'>;
+export type PathProps = {
+  d?: string;
+  fillRule?: 'evenodd' | 'nonzero';
+  clipRule?: 'evenodd' | 'nonzero';
+  children?: ReactElementChild | ReactElementChild[];
+};
 
-export type StopProps = Omit<BoxProps<typeof RNStop>, 'ref'>;
+export type StopProps = {
+  offset?: number;
+  stopColor?: string;
+};
 
-export type SvgProps = Omit<BoxProps<typeof RNSvg>, Exclude<keyof SystemProps, 'fill' | 'height' | 'width'> | 'ref'>;
+export type SvgProps = Pick<SizingSystemProps, 'height' | 'width'> &
+  SvgSystemProps & {
+    viewBox?: string;
+    children?: ReactElementChild | ReactElementChild[];
+  };
 
 export type SvgComponentType = FC<SvgProps> & {
   ClipPath: FC<ClipPathProps>;


### PR DESCRIPTION

<img width="1131" alt="스크린샷 2022-08-24 오후 2 25 41" src="https://user-images.githubusercontent.com/33626219/186340226-21744e61-d49b-4eac-ba2a-d8749352ba3c.png">

<img width="439" alt="스크린샷 2022-08-24 오후 2 24 41" src="https://user-images.githubusercontent.com/33626219/186340216-1d4db523-b686-429d-9b93-e020c121ff4b.png">