### PR TITLE
refactor: 불필요한 forwardRef 제거

### DIFF
--- a/packages/vibrant-components/src/lib/SelectOptionItem/SelectOptionItem.tsx
+++ b/packages/vibrant-components/src/lib/SelectOptionItem/SelectOptionItem.tsx
@@ -1,39 +1,36 @@
-import { forwardRef } from 'react';
 import { Box } from '@vibrant-ui/core';
 import { Body } from '../Body';
 import { Pressable } from '../Pressable';
 import { withSelectOptionItemVariation } from './SelectOptionItemProps';
 
-export const SelectOptionItem = withSelectOptionItemVariation(
-  forwardRef(({ innerRef, active, children, ...restProps }) => (
-    <Box
-      ref={innerRef}
-      as="li"
-      base={Pressable}
-      p={16}
-      color="onView1"
-      width="100%"
-      cursor="pointer"
-      overlayColor="onView1"
-      interactions={['hover', 'active']}
-      flexShrink={0}
-      {...restProps}
-    >
-      <>
-        {active && (
-          <Box
-            position="absolute"
-            zIndex={-1}
-            left={0}
-            right={0}
-            top={0}
-            bottom={0}
-            backgroundColor="onView1"
-            opacity="overlay.active"
-          />
-        )}
-        <Body level={2}>{children}</Body>
-      </>
-    </Box>
-  ))
-);
+export const SelectOptionItem = withSelectOptionItemVariation(({ innerRef, active, children, ...restProps }) => (
+  <Box
+    ref={innerRef}
+    as="li"
+    base={Pressable}
+    p={16}
+    color="onView1"
+    width="100%"
+    cursor="pointer"
+    overlayColor="onView1"
+    interactions={['hover', 'active']}
+    flexShrink={0}
+    {...restProps}
+  >
+    <>
+      {active && (
+        <Box
+          position="absolute"
+          zIndex={-1}
+          left={0}
+          right={0}
+          top={0}
+          bottom={0}
+          backgroundColor="onView1"
+          opacity="overlay.active"
+        />
+      )}
+      <Body level={2}>{children}</Body>
+    </>
+  </Box>
+));


### PR DESCRIPTION
```
Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?
```
워닝이 나고 있어서 불필요한 forwardRef를 제거해주었습니다