### PR TITLE
chore(utils-eslint-config): 테스트 코드 린트 룰과 config 타입 추론을 설정한다

### DIFF
--- a/packages/utils-eslint-config/src/index.js
+++ b/packages/utils-eslint-config/src/index.js
@@ -7,6 +7,7 @@ const reactHooksRules = require('./rules/react-hooks');
 const typescriptRules = require('./rules/typescript');
 const unusedImportsRules = require('./rules/unused-imports');
 
+/** @type {import('eslint').ESLint.ConfigData} */
 const eslintConfig = {
   extends: ['plugin:@nrwl/nx/javascript', 'prettier'],
   plugins: ['@nrwl/nx', 'prettier', 'react', 'react-hooks', 'import', 'unused-imports'],
@@ -58,6 +59,12 @@ const eslintConfig = {
             skipComments: false,
           },
         ],
+      },
+    },
+    {
+      files: ['*.spec.ts', '*.spec.tsx'],
+      rules: {
+        'react-hooks/rules-of-hooks': ['off'],
       },
     },
   ],


### PR DESCRIPTION
- 테스트 코드가 있는 파일에서는 `react-hooks/rules-of-hooks` 룰을 껐습니다.
- 린트 설정할 때 타입 추론이 되도록 수정했습니다.