### PR TITLE
fix(vibrant-core): update placeholderColor systemProp to apply text-fill-color style

### DIFF
--- a/packages/vibrant-components/src/lib/NumericField/__snapshots__/NumericField.spec.tsx.snap
+++ b/packages/vibrant-components/src/lib/NumericField/__snapshots__/NumericField.spec.tsx.snap
@@ -67,18 +67,26 @@ exports[`<NumericField /> when NumericField rendered match snapshot 1`] = `
 
 .emotion-1::-webkit-input-placeholder {
   color: #7C7C7C;
+  -webkit-text-fill-color: #7C7C7C;
+  text-fill-color: #7C7C7C;
 }
 
 .emotion-1::-moz-placeholder {
   color: #7C7C7C;
+  -webkit-text-fill-color: #7C7C7C;
+  text-fill-color: #7C7C7C;
 }
 
 .emotion-1:-ms-input-placeholder {
   color: #7C7C7C;
+  -webkit-text-fill-color: #7C7C7C;
+  text-fill-color: #7C7C7C;
 }
 
 .emotion-1::placeholder {
   color: #7C7C7C;
+  -webkit-text-fill-color: #7C7C7C;
+  text-fill-color: #7C7C7C;
 }
 
 .emotion-2 {

--- a/packages/vibrant-core/src/lib/props/input/input.ts
+++ b/packages/vibrant-core/src/lib/props/input/input.ts
@@ -6,6 +6,7 @@ const placeholderColorProp = createSystemProp({
   transform: value => ({
     '&::placeholder': {
       color: value,
+      textFillColor: value,
     },
   }),
 });


### PR DESCRIPTION
### Before
<img width="754" alt="스크린샷 2022-08-26 오후 5 14 20" src="https://user-images.githubusercontent.com/33626219/186855876-60e88b33-d8b8-4753-a768-4b69e98e8e5c.png">


### After
<img width="761" alt="스크린샷 2022-08-26 오후 4 58 40" src="https://user-images.githubusercontent.com/33626219/186855621-49bb97b2-a23e-4d02-a0bc-e2feefefe943.png">
