### PR TITLE
fix(vibrant-components): change Icon weight regular to thin

### DIFF
--- a/packages/vibrant-components/src/lib/PasswordField/PasswordField.tsx
+++ b/packages/vibrant-components/src/lib/PasswordField/PasswordField.tsx
@@ -27,11 +27,7 @@ export const PasswordField = withPasswordFieldVariation(
         onLabelClick={() => inputRef.current?.focus()}
         renderSuffix={() => (
           <PressableBox onClick={() => setShowValue(!showValue)}>
-            {showValue ? (
-              <Icon.EyeOn.Regular size={20} fill="onView2" />
-            ) : (
-              <Icon.EyeOff.Regular size={20} fill="onView2" />
-            )}
+            {showValue ? <Icon.EyeOn.Thin size={20} fill="onView2" /> : <Icon.EyeOff.Thin size={20} fill="onView2" />}
           </PressableBox>
         )}
         renderField={style => (


### PR DESCRIPTION

## Before
![Simulator Screen Shot - iPhone 13 - 2022-08-30 at 01 50 05](https://user-images.githubusercontent.com/33626219/187252888-ea46a9a7-0b03-48cc-86ed-80db7725e36d.png)
![스크린샷 2022-08-30 오전 1 50 09](https://user-images.githubusercontent.com/33626219/187252892-b60e5f53-2156-4767-a284-44c79e0b7c88.png)

## After
![Simulator Screen Shot - iPhone 13 - 2022-08-30 at 01 49 52](https://user-images.githubusercontent.com/33626219/187252946-6636ff15-0170-4ce6-8bc8-75e1dd9790cc.png)
![스크린샷 2022-08-30 오전 1 49 56](https://user-images.githubusercontent.com/33626219/187252950-721d047e-520b-42f6-b295-c30ce5dffbf0.png)
