### PR TITLE
fix(vibrant-components): helperText only render when value is exists

### DIFF
--- a/packages/vibrant-components/src/lib/FieldLayout/FieldLayout.tsx
+++ b/packages/vibrant-components/src/lib/FieldLayout/FieldLayout.tsx
@@ -86,9 +86,11 @@ export const FieldLayout = withFieldLayoutVariation(
         </Box>
         {renderSuffix?.()}
       </Box>
-      <Body level={4} color={textColor}>
-        {helperText}
-      </Body>
+      {Boolean(helperText) && (
+        <Body level={4} color={textColor}>
+          {helperText}
+        </Body>
+      )}
     </VStack>
   )
 );


### PR DESCRIPTION
## Before
![스크린샷 2022-08-30 오전 1 57 28](https://user-images.githubusercontent.com/33626219/187254117-93c75842-6794-48d0-9960-4aa957973821.png)

## After
![스크린샷 2022-08-30 오전 1 52 57](https://user-images.githubusercontent.com/33626219/187254111-ba50dc60-5974-42dc-8e1b-40c778fe6cde.png)
