### PR TITLE
fix(vibrant-components): fix contentArea padding type to responsiveValue type

### DIFF
--- a/packages/vibrant-components/src/lib/FloatingActionButton/FloatingActionButton.tsx
+++ b/packages/vibrant-components/src/lib/FloatingActionButton/FloatingActionButton.tsx
@@ -1,5 +1,12 @@
 import { useMemo } from 'react';
-import { PortalBox, PressableBox, useCurrentTheme, useSafeArea, useWindowDimensions } from '@vibrant-ui/core';
+import {
+  PortalBox,
+  PressableBox,
+  transformResponsiveValue,
+  useCurrentTheme,
+  useSafeArea,
+  useWindowDimensions,
+} from '@vibrant-ui/core';
 import { withFloatingActionButtonVariation } from './FloatingActionButtonProps';
 
 export const FloatingActionButton = withFloatingActionButtonVariation(
@@ -12,7 +19,10 @@ export const FloatingActionButton = withFloatingActionButtonVariation(
 
     const offsetProps = useMemo(
       () => ({
-        [position]: Math.max(viewportWidth - contentArea.maxWidth, 0) / 2 + contentArea.padding,
+        [position]: transformResponsiveValue(
+          contentArea.padding,
+          value => Math.max(viewportWidth - contentArea.maxWidth, 0) / 2 + value
+        ),
         bottom:
           typeof insets.bottom === 'string' ? `max(${insets.bottom}, ${offset}px)` : Math.max(insets.bottom, offset),
       }),

--- a/packages/vibrant-theme/src/types/Theme.ts
+++ b/packages/vibrant-theme/src/types/Theme.ts
@@ -10,7 +10,7 @@ export type Theme = {
   breakpoints: number[];
   contentArea: {
     maxWidth: number;
-    padding: number;
+    padding: number[] | number;
   };
   colors: ThemeColors;
   elevation: ThemeElevation;
@@ -26,7 +26,7 @@ export type CurrentTheme = {
   breakpoints: number[];
   contentArea: {
     maxWidth: number;
-    padding: number;
+    padding: number[] | number;
   };
   colors: Colors;
   elevation: Elevation;


### PR DESCRIPTION

<img width="568" alt="스크린샷 2022-08-30 오전 10 16 55" src="https://user-images.githubusercontent.com/33626219/187326441-2ed00d84-4874-4f03-bc53-fbf51b69fc2e.png">
