### PR TITLE
fix(vibrant-core): add default value to safe area variable

### DIFF
--- a/packages/vibrant-core/src/lib/SafeAreaProvider/SafeAreaProvider.tsx
+++ b/packages/vibrant-core/src/lib/SafeAreaProvider/SafeAreaProvider.tsx
@@ -5,9 +5,9 @@ export const SafeAreaProvider: FC<SafeAreaProviderProps> = ({ children }) => <>{
 
 export const useSafeArea = (): SafeAreaContextValue => ({
   insets: {
-    top: 'var(--safe-area-inset-top)',
-    left: 'var(--safe-area-inset-left)',
-    right: 'var(--safe-area-inset-right)',
-    bottom: 'var(--safe-area-inset-bottom)',
+    top: 'var(--safe-area-inset-top, 0px)',
+    left: 'var(--safe-area-inset-left, 0px)',
+    right: 'var(--safe-area-inset-right, 0px)',
+    bottom: 'var(--safe-area-inset-bottom, 0px)',
   },
 });


### PR DESCRIPTION
## Before
<img width="302" alt="image" src="https://user-images.githubusercontent.com/33626219/187327109-e3f163ac-603c-4cb7-bc36-16a65b431586.png">
<img width="293" alt="스크린샷 2022-08-30 오전 10 19 47" src="https://user-images.githubusercontent.com/33626219/187327008-dd470a49-be52-480c-8082-a3ccaf089701.png">

## After
<img width="299" alt="스크린샷 2022-08-30 오전 10 19 18" src="https://user-images.githubusercontent.com/33626219/187327010-5812eb48-ac49-4ac0-8054-6dc5f04f1b47.png">
<img width="242" alt="스크린샷 2022-08-30 오전 10 19 54" src="https://user-images.githubusercontent.com/33626219/187327002-a3997813-7f19-46fa-b694-690d233be102.png">