### PR TITLE
fix(vibrant-theme): update overlay opacity value

### DIFF
--- a/packages/vibrant-theme/src/lib/theme/darkModeOpacity.ts
+++ b/packages/vibrant-theme/src/lib/theme/darkModeOpacity.ts
@@ -2,9 +2,9 @@ import type { Opacity } from '../../types';
 
 export const darkModeOpacity: Opacity = {
   overlay: {
-    hover: 0.16,
-    focus: 0.2,
-    active: 0.24,
+    hover: 0.075,
+    focus: 0.125,
+    active: 0.125,
   },
   text: {
     focus: 0.8,

--- a/packages/vibrant-theme/src/lib/theme/lightModeOpacity.ts
+++ b/packages/vibrant-theme/src/lib/theme/lightModeOpacity.ts
@@ -2,9 +2,9 @@ import type { Opacity } from '../../types';
 
 export const lightModeOpacity: Opacity = {
   overlay: {
-    hover: 0.08,
-    focus: 0.12,
-    active: 0.16,
+    hover: 0.025,
+    focus: 0.075,
+    active: 0.075,
   },
   text: {
     focus: 0.8,


### PR DESCRIPTION
## Before
https://user-images.githubusercontent.com/33626219/187405665-de5e0d5f-e94a-4223-958a-01ac28a2f0e1.mov

## After
https://user-images.githubusercontent.com/33626219/187405674-2a1f2794-fbd4-4e17-b5fc-5c2cb228a165.mov

