### PR TITLE
fix(vibrant-components): change text opacity animation to apply to children

### DIFF
--- a/packages/vibrant-components/src/lib/Backdrop/Backdrop.tsx
+++ b/packages/vibrant-components/src/lib/Backdrop/Backdrop.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Box, PortalBox } from '@vibrant-ui/core';
+import { PortalBox } from '@vibrant-ui/core';
 import { Motion } from '@vibrant-ui/motion';
 import { Pressable } from '../Pressable';
 import { withBackdropVariation } from './BackdropProps';
@@ -36,9 +36,8 @@ export const Backdrop = withBackdropVariation(
           duration={transitionDuration}
           onEnd={unmount}
         >
-          <Box
+          <Pressable
             as="div"
-            base={Pressable}
             position="absolute"
             zIndex={-1}
             cursor="default"

--- a/packages/vibrant-components/src/lib/CalendarDateItem/CalenderDateItem.tsx
+++ b/packages/vibrant-components/src/lib/CalendarDateItem/CalenderDateItem.tsx
@@ -5,7 +5,7 @@ import { withCalendarDateItemVariation } from './CalendarDateItemProps';
 
 export const CalenderDateItem = withCalendarDateItemVariation(
   ({ date, onClick, color, today, range, ...restProps }) => (
-    <Box base={Pressable} onClick={() => onClick(date)} position="relative" overflow="visible" width={40} height={40}>
+    <Pressable onClick={() => onClick(date)} position="relative" overflow="visible" width={40} height={40}>
       <>
         <Box
           position="absolute"
@@ -61,6 +61,6 @@ export const CalenderDateItem = withCalendarDateItemVariation(
           )}
         </Box>
       </>
-    </Box>
+    </Pressable>
   )
 );

--- a/packages/vibrant-components/src/lib/DateInput/DateInput.tsx
+++ b/packages/vibrant-components/src/lib/DateInput/DateInput.tsx
@@ -32,14 +32,12 @@ export const DateInput = withDateInputVariation(
 
     return (
       <Box width="100%" position="relative">
-        <Box<typeof Pressable>
+        <Pressable
           ref={innerRef}
-          base={Pressable}
           width="100%"
           borderWidth={1}
           borderStyle="solid"
           borderColor={(isFocused || calendarOpened) && state !== 'error' ? 'outlineNeutral' : borderColor}
-          typography="body2"
           p={15}
           py={isContentExists && label ? 7 : 14}
           pr={disabled ? 48 : 80}
@@ -61,7 +59,7 @@ export const DateInput = withDateInputVariation(
               {value || label || placeholder}
             </Body>
           </VStack>
-        </Box>
+        </Pressable>
 
         <Box position="absolute" top={15} right={15}>
           <HStack spacing={12}>

--- a/packages/vibrant-components/src/lib/Dropdown/Dropdown.stories.tsx
+++ b/packages/vibrant-components/src/lib/Dropdown/Dropdown.stories.tsx
@@ -14,26 +14,26 @@ const DropdownContent = () => {
 
   return opened ? (
     <VStack spacing={20} px={20}>
-      <Box base={Pressable} onClick={() => setOpened(false)}>
+      <Pressable onClick={() => setOpened(false)}>
         <HStack alignItems="center" spacing={4}>
           <Icon.ChevronLeft.Regular size={16} />
           <Title level={6}>화질</Title>
         </HStack>
-      </Box>
+      </Pressable>
       <Body level={2}>1080p</Body>
       <Body level={2}>720p</Body>
       <Body level={2}>540p</Body>
     </VStack>
   ) : (
     <VStack spacing={20}>
-      <Box base={Pressable} onClick={() => setOpened(true)}>
+      <Pressable onClick={() => setOpened(true)}>
         <HStack px={20} alignment="space-between" alignItems="flex-end">
           <Body level={2}>화질</Body>
           <Body level={3} color="onView2">
             1080p
           </Body>
         </HStack>
-      </Box>
+      </Pressable>
       <HStack px={20} alignment="space-between" alignItems="flex-end">
         <Body level={2}>자동 재생</Body>
         <Body level={3} color="onView2">
@@ -50,9 +50,9 @@ export default {
   args: {
     renderContents: () => <DropdownContent />,
     renderOpener: open => (
-      <Box base={Pressable} backgroundColor="primary" onClick={open} p={20} height={100}>
+      <Pressable backgroundColor="primary" onClick={open} p={20} height={100}>
         <Body level={1}>Click Me</Body>
-      </Box>
+      </Pressable>
     ),
     position: 'bottom',
     spacing: 8,

--- a/packages/vibrant-components/src/lib/FloatingActionButton/FloatingActionButton.tsx
+++ b/packages/vibrant-components/src/lib/FloatingActionButton/FloatingActionButton.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import {
-  Box,
   PortalBox,
   transformResponsiveValue,
   useCurrentTheme,
@@ -11,7 +10,7 @@ import { Pressable } from '../Pressable';
 import { withFloatingActionButtonVariation } from './FloatingActionButtonProps';
 
 export const FloatingActionButton = withFloatingActionButtonVariation(
-  ({ position = 'right', offset = 20, IconComponent, ...restProps }) => {
+  ({ position = 'right', offset = 20, IconComponent, innerRef, ...restProps }) => {
     const { insets } = useSafeArea();
     const { width: viewportWidth } = useWindowDimensions();
     const {
@@ -32,8 +31,8 @@ export const FloatingActionButton = withFloatingActionButtonVariation(
 
     return (
       <PortalBox {...offsetProps} zIndex={1}>
-        <Box
-          base={Pressable}
+        <Pressable
+          ref={innerRef}
           width={50}
           height={50}
           borderRadius={25}
@@ -46,7 +45,7 @@ export const FloatingActionButton = withFloatingActionButtonVariation(
           {...restProps}
         >
           <IconComponent size={20} />
-        </Box>
+        </Pressable>
       </PortalBox>
     );
   }

--- a/packages/vibrant-components/src/lib/FloatingActionButton/FloatingActionButtonProps.ts
+++ b/packages/vibrant-components/src/lib/FloatingActionButton/FloatingActionButtonProps.ts
@@ -1,8 +1,9 @@
-import type { ComponentType } from 'react';
+import type { ComponentType, Ref } from 'react';
 import { withVariation } from '@vibrant-ui/core';
 import type { IconProps } from '@vibrant-ui/icons';
 
 type FloatingActionButtonProps = {
+  ref?: Ref<any>;
   position?: 'left' | 'right';
   offset?: number;
   onClick: () => void;

--- a/packages/vibrant-components/src/lib/NumericField/__snapshots__/NumericField.spec.tsx.snap
+++ b/packages/vibrant-components/src/lib/NumericField/__snapshots__/NumericField.spec.tsx.snap
@@ -126,9 +126,9 @@ exports[`<NumericField /> when NumericField rendered match snapshot 1`] = `
   flex-shrink: 1;
   box-sizing: border-box;
   cursor: pointer;
-  background-color: inherit;
+  background-color: rgba(0, 0, 0, 0.05);
   border-width: 0;
-  padding: 0;
+  padding: 7px;
   position: relative;
   overflow: hidden;
   -webkit-align-items: stretch;
@@ -136,24 +136,7 @@ exports[`<NumericField /> when NumericField rendered match snapshot 1`] = `
   -ms-flex-align: stretch;
   align-items: stretch;
   z-index: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
-  align-content: stretch;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  box-sizing: border-box;
-  padding: 7px;
-  border-width: 0;
   border-radius: 2px;
-  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .emotion-4 {
@@ -195,9 +178,8 @@ exports[`<NumericField /> when NumericField rendered match snapshot 1`] = `
   -ms-flex-negative: 1;
   flex-shrink: 1;
   box-sizing: border-box;
-  width: 16px;
-  height: 16px;
-  fill: #0C0C0C;
+  width: auto;
+  height: auto;
 }
 
 .emotion-6 {
@@ -215,9 +197,29 @@ exports[`<NumericField /> when NumericField rendered match snapshot 1`] = `
   -ms-flex-negative: 1;
   flex-shrink: 1;
   box-sizing: border-box;
+  width: 16px;
+  height: 16px;
+  fill: #0C0C0C;
 }
 
 .emotion-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  box-sizing: border-box;
+}
+
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -254,43 +256,51 @@ exports[`<NumericField /> when NumericField rendered match snapshot 1`] = `
     >
       <button
         class="emotion-3"
-        style="opacity: 1;"
       >
         <div
           class="emotion-4"
           style="opacity: 0;"
         />
-        <svg
+        <div
           class="emotion-5"
-          viewBox="0 0 24 24"
+          style="opacity: 1;"
         >
-          <path
+          <svg
             class="emotion-6"
-            d="M21.25 13.25H2.75c-.15 0-.25-.1-.25-.25v-2c0-.15.1-.25.25-.25h18.5c.15 0 .25.1.25.25v2c0 .15-.1.25-.25.25Z"
-          />
-        </svg>
+            viewBox="0 0 24 24"
+          >
+            <path
+              class="emotion-7"
+              d="M21.25 13.25H2.75c-.15 0-.25-.1-.25-.25v-2c0-.15.1-.25.25-.25h18.5c.15 0 .25.1.25.25v2c0 .15-.1.25-.25.25Z"
+            />
+          </svg>
+        </div>
       </button>
     </div>
     <div
-      class="emotion-7"
+      class="emotion-8"
     >
       <button
         class="emotion-3"
-        style="opacity: 1;"
       >
         <div
           class="emotion-4"
           style="opacity: 0;"
         />
-        <svg
+        <div
           class="emotion-5"
-          viewBox="0 0 24 24"
+          style="opacity: 1;"
         >
-          <path
+          <svg
             class="emotion-6"
-            d="M21.25 10.75h-8v-8c0-.15-.1-.25-.25-.25h-2c-.15 0-.25.1-.25.25v8h-8c-.15 0-.25.1-.25.25v2c0 .15.1.25.25.25h8v8c0 .15.1.25.25.25h2c.15 0 .25-.1.25-.25v-8h8c.15 0 .25-.1.25-.25v-2c0-.15-.1-.25-.25-.25Z"
-          />
-        </svg>
+            viewBox="0 0 24 24"
+          >
+            <path
+              class="emotion-7"
+              d="M21.25 10.75h-8v-8c0-.15-.1-.25-.25-.25h-2c-.15 0-.25.1-.25.25v8h-8c-.15 0-.25.1-.25.25v2c0 .15.1.25.25.25h8v8c0 .15.1.25.25.25h2c.15 0 .25-.1.25-.25v-8h8c.15 0 .25-.1.25-.25v-2c0-.15-.1-.25-.25-.25Z"
+            />
+          </svg>
+        </div>
       </button>
     </div>
   </div>

--- a/packages/vibrant-components/src/lib/OperatorButton/OperatorButton.tsx
+++ b/packages/vibrant-components/src/lib/OperatorButton/OperatorButton.tsx
@@ -1,11 +1,9 @@
-import { Box } from '@vibrant-ui/core';
 import { Pressable } from '../Pressable';
 import { withOperationButtonVariation } from './OperatorButtonProps';
 
 export const OperatorButton = withOperationButtonVariation(
   ({ IconComponent, backgroundColor, iconFill, ...restProps }) => (
-    <Box
-      base={Pressable}
+    <Pressable
       p={7}
       borderWidth={0}
       borderRadius={2}
@@ -15,6 +13,6 @@ export const OperatorButton = withOperationButtonVariation(
       {...restProps}
     >
       <IconComponent size={16} fill={iconFill} />
-    </Box>
+    </Pressable>
   )
 );

--- a/packages/vibrant-components/src/lib/OperatorButton/__snapshots__/OperatorButton.spec.tsx.snap
+++ b/packages/vibrant-components/src/lib/OperatorButton/__snapshots__/OperatorButton.spec.tsx.snap
@@ -17,9 +17,9 @@ exports[`<OperatorButton /> when OperatorButton rendered match snapshot 1`] = `
   flex-shrink: 1;
   box-sizing: border-box;
   cursor: pointer;
-  background-color: inherit;
+  background-color: rgba(0, 0, 0, 0.05);
   border-width: 0;
-  padding: 0;
+  padding: 7px;
   position: relative;
   overflow: hidden;
   -webkit-align-items: stretch;
@@ -27,24 +27,7 @@ exports[`<OperatorButton /> when OperatorButton rendered match snapshot 1`] = `
   -ms-flex-align: stretch;
   align-items: stretch;
   z-index: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
-  align-content: stretch;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  box-sizing: border-box;
-  padding: 7px;
-  border-width: 0;
   border-radius: 2px;
-  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .emotion-1 {
@@ -86,12 +69,31 @@ exports[`<OperatorButton /> when OperatorButton rendered match snapshot 1`] = `
   -ms-flex-negative: 1;
   flex-shrink: 1;
   box-sizing: border-box;
+  width: auto;
+  height: auto;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  box-sizing: border-box;
   width: 16px;
   height: 16px;
   fill: #0C0C0C;
 }
 
-.emotion-3 {
+.emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -112,21 +114,25 @@ exports[`<OperatorButton /> when OperatorButton rendered match snapshot 1`] = `
   <button
     class="emotion-0"
     data-testid="operatorButton"
-    style="opacity: 1;"
   >
     <div
       class="emotion-1"
       style="opacity: 0;"
     />
-    <svg
+    <div
       class="emotion-2"
-      viewBox="0 0 24 24"
+      style="opacity: 1;"
     >
-      <path
+      <svg
         class="emotion-3"
-        d="M21.25 10.75h-8v-8c0-.15-.1-.25-.25-.25h-2c-.15 0-.25.1-.25.25v8h-8c-.15 0-.25.1-.25.25v2c0 .15.1.25.25.25h8v8c0 .15.1.25.25.25h2c.15 0 .25-.1.25-.25v-8h8c.15 0 .25-.1.25-.25v-2c0-.15-.1-.25-.25-.25Z"
-      />
-    </svg>
+        viewBox="0 0 24 24"
+      >
+        <path
+          class="emotion-4"
+          d="M21.25 10.75h-8v-8c0-.15-.1-.25-.25-.25h-2c-.15 0-.25.1-.25.25v8h-8c-.15 0-.25.1-.25.25v2c0 .15.1.25.25.25h8v8c0 .15.1.25.25.25h2c.15 0 .25-.1.25-.25v-8h8c.15 0 .25-.1.25-.25v-2c0-.15-.1-.25-.25-.25Z"
+        />
+      </svg>
+    </div>
   </button>
 </div>
 `;

--- a/packages/vibrant-components/src/lib/Pressable/Pressable.tsx
+++ b/packages/vibrant-components/src/lib/Pressable/Pressable.tsx
@@ -6,6 +6,7 @@ import { withPressableVariation } from './PressableProp';
 
 export const Pressable = withPressableVariation(
   ({
+    innerRef,
     as = 'button',
     children,
     overlayColor,
@@ -14,6 +15,8 @@ export const Pressable = withPressableVariation(
     onClick,
     interactions,
     disabled = false,
+    width,
+    height,
     ...restProps
   }) => {
     const [isFocused, setIsFocused] = useState(false);
@@ -30,47 +33,45 @@ export const Pressable = withPressableVariation(
     });
 
     return (
-      <Transition animation={{ opacity: textOpacity }} duration={200} {...restProps}>
-        <PressableBox
-          as={as}
-          position="relative"
-          overflow="hidden"
-          cursor={disabled ? 'default' : 'pointer'}
-          alignItems="stretch"
-          zIndex={0}
-          disabled={disabled}
-          onClick={onClick}
-          onHoverIn={() => setIsHovered(true)}
-          onHoverOut={() => setIsHovered(false)}
-          onFocusIn={() => {
-            setIsFocused(true);
+      <PressableBox
+        ref={innerRef}
+        as={as}
+        position="relative"
+        overflow="hidden"
+        cursor={disabled ? 'default' : 'pointer'}
+        alignItems="stretch"
+        zIndex={0}
+        disabled={disabled}
+        width={width}
+        height={height}
+        onClick={onClick}
+        onHoverIn={() => setIsHovered(true)}
+        onHoverOut={() => setIsHovered(false)}
+        onFocusIn={() => {
+          setIsFocused(true);
 
-            onFocus?.();
-          }}
-          onFocusOut={() => {
-            setIsFocused(false);
+          onFocus?.();
+        }}
+        onFocusOut={() => {
+          setIsFocused(false);
 
-            onBlur?.();
-          }}
-          onPressIn={() => setIsActivated(true)}
-          onPressOut={() => setIsActivated(false)}
-        >
-          {overlayColor && (
-            <Transition animation={{ opacity: overlayOpacity }} duration={200}>
-              <Box
-                position="absolute"
-                zIndex={-1}
-                left={0}
-                right={0}
-                top={0}
-                bottom={0}
-                backgroundColor={overlayColor}
-              />
-            </Transition>
-          )}
-          {children}
-        </PressableBox>
-      </Transition>
+          onBlur?.();
+        }}
+        onPressIn={() => setIsActivated(true)}
+        onPressOut={() => setIsActivated(false)}
+        {...restProps}
+      >
+        {overlayColor && (
+          <Transition animation={{ opacity: overlayOpacity }} duration={200}>
+            <Box position="absolute" zIndex={-1} left={0} right={0} top={0} bottom={0} backgroundColor={overlayColor} />
+          </Transition>
+        )}
+        <Transition animation={{ opacity: textOpacity }} duration={200}>
+          <Box width={width ? '100%' : 'auto'} height={height ? '100%' : 'auto'}>
+            {children}
+          </Box>
+        </Transition>
+      </PressableBox>
     );
   }
 );

--- a/packages/vibrant-components/src/lib/Pressable/PressableProp.ts
+++ b/packages/vibrant-components/src/lib/Pressable/PressableProp.ts
@@ -1,26 +1,45 @@
 import type { ReactElement, Ref } from 'react';
-import type { ResponsiveValue } from '@vibrant-ui/core';
+import type {
+  BackgroundSystemProps,
+  BorderSystemProps,
+  ColorSystemProps,
+  ElevationSystemProps,
+  FlexboxSystemProps,
+  OverflowSystemProps,
+  PositionSystemProps,
+  ResponsiveValue,
+  SizingSystemProps,
+  SpacingSystemProps,
+} from '@vibrant-ui/core';
 import { withVariation } from '@vibrant-ui/core';
 import type { ColorToken } from '@vibrant-ui/theme';
 
-export type PressableProps = {
-  ref?: Ref<any>;
-  as?: 'button' | 'div' | 'li';
-  disabled?: boolean;
-  children?: ReactElement;
-  cursor?: 'default' | 'pointer';
-  onClick?: () => void;
-  onFocus?: () => void;
-  onBlur?: () => void;
-} & (
-  | {
-      overlayColor: ResponsiveValue<ColorToken>;
-      interactions?: ('active' | 'focus' | 'hover')[];
-    }
-  | {
-      overlayColor?: never;
-      interactions?: ('active' | 'focus')[];
-    }
-);
+export type PressableProps = BackgroundSystemProps &
+  BorderSystemProps &
+  ColorSystemProps &
+  ElevationSystemProps &
+  FlexboxSystemProps &
+  OverflowSystemProps &
+  PositionSystemProps &
+  SpacingSystemProps &
+  SizingSystemProps & {
+    ref?: Ref<any>;
+    as?: 'button' | 'div' | 'li';
+    disabled?: boolean;
+    children?: ReactElement;
+    cursor?: 'default' | 'pointer';
+    onClick?: () => void;
+    onFocus?: () => void;
+    onBlur?: () => void;
+  } & (
+    | {
+        overlayColor: ResponsiveValue<ColorToken>;
+        interactions?: ('active' | 'focus' | 'hover')[];
+      }
+    | {
+        overlayColor?: never;
+        interactions?: ('active' | 'focus')[];
+      }
+  );
 
 export const withPressableVariation = withVariation<PressableProps>('Pressable')();

--- a/packages/vibrant-components/src/lib/SelectOptionItem/SelectOptionItem.tsx
+++ b/packages/vibrant-components/src/lib/SelectOptionItem/SelectOptionItem.tsx
@@ -4,10 +4,9 @@ import { Pressable } from '../Pressable';
 import { withSelectOptionItemVariation } from './SelectOptionItemProps';
 
 export const SelectOptionItem = withSelectOptionItemVariation(({ innerRef, active, children, ...restProps }) => (
-  <Box
+  <Pressable
     ref={innerRef}
     as="li"
-    base={Pressable}
     p={16}
     color="onView1"
     width="100%"
@@ -32,5 +31,5 @@ export const SelectOptionItem = withSelectOptionItemVariation(({ innerRef, activ
       )}
       <Body level={2}>{children}</Body>
     </>
-  </Box>
+  </Pressable>
 ));

--- a/packages/vibrant-components/src/lib/Switch/Switch.tsx
+++ b/packages/vibrant-components/src/lib/Switch/Switch.tsx
@@ -26,8 +26,7 @@ export const Switch = withSwitchVariation(
         }}
         duration={200}
       >
-        <Box
-          base={Pressable}
+        <Pressable
           width={width}
           height={height}
           borderRadius={borderRadius}
@@ -38,7 +37,7 @@ export const Switch = withSwitchVariation(
           <Transition animation={{ x: isChecked ? roundSize : 0 }} duration={200}>
             <Box width={roundSize} height={roundSize} borderRadius={roundRadius} backgroundColor="white" />
           </Transition>
-        </Box>
+        </Pressable>
       </Transition>
     );
   }


### PR DESCRIPTION
## Dropdown
https://user-images.githubusercontent.com/33626219/187507404-6ceae23c-3d6c-46b2-988e-cb6a9575b1c2.mov

https://user-images.githubusercontent.com/33626219/187507418-6c530e05-382d-4ea1-82d0-00a8e95f5b02.mp4

## SelectOptionItem

https://user-images.githubusercontent.com/33626219/187507482-5f24f6da-ebe8-444a-898d-799f4aba589a.mov

https://user-images.githubusercontent.com/33626219/187507475-284b8e91-8fff-49cb-bac0-03abad6a366c.mp4

## Switch

https://user-images.githubusercontent.com/33626219/187507549-dcfd5184-d2a6-4444-a240-53f0428e5213.mov

https://user-images.githubusercontent.com/33626219/187507554-71d63d34-e41f-4952-9264-3e5768385f1b.mp4

