### PR TITLE
feat: createSHadowsComponent에서 offset이 0인 경우 paintInside 옵션을 false로 준다

### DIFF
--- a/packages/vibrant-components/src/lib/createShadowsComponent/createShadowsComponent.tsx
+++ b/packages/vibrant-components/src/lib/createShadowsComponent/createShadowsComponent.tsx
@@ -7,6 +7,7 @@ type ShadowComponentType = ComponentType<{
   distance?: any;
   offset?: any;
   viewStyle?: any;
+  paintInside?: boolean;
   children?: ReactNode;
 }>;
 
@@ -22,7 +23,11 @@ type ShadowsProps = {
 
 export const createShadowsComponent = (ShadowComponent: ShadowComponentType) => {
   const ShadowsComponent = forwardRef<any, ShadowsProps>(({ shadows, style, children }, ref) => (
-    <ShadowComponent viewStyle={shadows.length <= 1 ? style : undefined} {...(shadows[0] ?? { distance: 0 })}>
+    <ShadowComponent
+      paintInside={!(shadows?.[0].offset?.[0] === 0 && shadows?.[0].offset?.[1] === 0)}
+      viewStyle={shadows.length <= 1 ? style : undefined}
+      {...(shadows[0] ?? { distance: 0 })}
+    >
       {shadows.length <= 1 ? (
         <Box ref={ref}>{children}</Box>
       ) : (


### PR DESCRIPTION
### after (backgroundColor 제거한 상태)
<img width="410" alt="image" src="https://user-images.githubusercontent.com/37496919/187577720-18f5923e-ff25-42c1-bd72-f63257340b22.png">

### before (backgroundColor 제거한 상태)
<img width="390" alt="image" src="https://user-images.githubusercontent.com/37496919/187577767-0f6c36cb-415b-4d40-bc4b-f8dc30f6eafa.png">

react-native-shadow-2에서 offset이 존재하는 경우 paintinside 옵션(startColor로 fill 함)을 true로 설정하는데 기본값으로 [0, 0]을 넘겨주고 있어서 paintinside이 항상 true로 설정되었습니다. 이것을 offset이 0 0 인 경우 false로 설정하도록 수정합니다. 해당 내용 적용하니 높이 전환 애니메이션 시에 회색 영역이 도드라지게 보이지 않게 되어 자연스러워 보이는 효과가 있었습니다.

참고 스레드: https://101inc.slack.com/archives/C03MNQ1JRJ8/p1661908779035449?thread_ts=1661843432.914269&cid=C03MNQ1JRJ8