### PR TITLE
fix: change background color of Dropdown to surface2

### DIFF
--- a/packages/vibrant-components/src/lib/Dropdown/Dropdown.tsx
+++ b/packages/vibrant-components/src/lib/Dropdown/Dropdown.tsx
@@ -6,6 +6,7 @@ import {
   getWindowDimensions,
   useCurrentThemeMode,
   useResponsiveValue,
+  useSafeArea,
   useWindowDimensions,
 } from '@vibrant-ui/core';
 import { Transition } from '@vibrant-ui/motion';
@@ -75,6 +76,7 @@ export const Dropdown = withDropdownVariation(
     const [offset, setOffset] = useState<{ x?: number; y?: number }>({});
     const [contentHeight, setContentHeight] = useState<number>();
     const { height: viewportHeight } = useWindowDimensions();
+    const { insets } = useSafeArea();
 
     const { breakpointIndex } = useResponsiveValue({ rootBreakPoints: true });
     const isMobile = breakpointIndex === 0;
@@ -231,7 +233,7 @@ export const Dropdown = withDropdownVariation(
                       }
                     >
                       <Box onLayout={handleContentResize} flexShrink={0}>
-                        {renderContents(closeDropdown)}
+                        <Box pb={insets.bottom}>{renderContents(closeDropdown)}</Box>
                       </Box>
                     </ScrollBox>
                   </Transition>


### PR DESCRIPTION
### before

<img width="963" alt="image" src="https://user-images.githubusercontent.com/37496919/188366220-45248474-6f50-4008-8010-2cb6e714e2de.png">

### after

<img width="994" alt="image" src="https://user-images.githubusercontent.com/37496919/188366169-44d88285-5745-48ea-addd-4fdf1e51ffdf.png">


(+ 바텀싯에서 첫 height 애니메이션 시 덜컥거리지 않게 height style을 준다)