### PR TITLE
fix(vibrant-components): fix disclosure icon align

### DIFF
--- a/packages/vibrant-components/src/lib/SelectField/SelectField.tsx
+++ b/packages/vibrant-components/src/lib/SelectField/SelectField.tsx
@@ -196,7 +196,7 @@ export const SelectField = withSelectFieldVariation(
               onClick={() => (isOpened ? close() : open(-1))}
               {...restProps}
             >
-              <HStack width="100%">
+              <HStack alignItems="center" width="100%">
                 <Box as="span" flex={1}>
                   {selectedOption ? (
                     <Box flexDirection={inlineLabel ? 'row' : 'column'}>


### PR DESCRIPTION
### Before
<img width="1075" alt="스크린샷 2022-09-06 오후 2 56 32" src="https://user-images.githubusercontent.com/33626219/188557953-2372ce9b-7ec3-4b21-b80f-bd0cef9e47a3.png">

### After
<img width="1078" alt="스크린샷 2022-09-06 오후 2 57 24" src="https://user-images.githubusercontent.com/33626219/188557961-9bdf5cb8-78dd-45e9-9827-540e2678e431.png">
