### PR TITLE
fix(vibrant-components): fix VerificationCodeField vertical spacing to 12px

### DIFF
--- a/packages/vibrant-components/src/lib/VerificationCodeField/VerificationCodeField.tsx
+++ b/packages/vibrant-components/src/lib/VerificationCodeField/VerificationCodeField.tsx
@@ -62,8 +62,8 @@ export const VerificationCodeField = withVerificationCodeFieldVariation(
           hidden={true}
         />
         <VStack alignment="center" spacing={8}>
-          <HStack alignment="center" flexWrap="wrap" mx={-4} my={-8}>
-            <HStack alignment="center" my={8}>
+          <HStack alignment="center" flexWrap="wrap" mx={-4} my={-6}>
+            <HStack alignment="center" my={6}>
               {Array.from({ length: splitIndex }).map((_, index) => (
                 <VStack key={index} mx={4}>
                   <VerificationCodeItem
@@ -78,7 +78,7 @@ export const VerificationCodeField = withVerificationCodeFieldVariation(
                 </VStack>
               ))}
             </HStack>
-            <HStack alignment="center" my={8}>
+            <HStack alignment="center" my={6}>
               {Array.from({ length: length - splitIndex }).map((_, index) => (
                 <VStack key={index + splitIndex} mx={4}>
                   <VerificationCodeItem


### PR DESCRIPTION
### Before
<img width="175" alt="스크린샷 2022-09-06 오후 3 01 56" src="https://user-images.githubusercontent.com/33626219/188558441-283471f2-885e-4d7c-8f88-d833777df216.png">

### After
<img width="180" alt="스크린샷 2022-09-06 오후 3 01 14" src="https://user-images.githubusercontent.com/33626219/188558444-a5938b29-3b65-4a0e-8775-4b7cc350eec6.png">
