### PR TITLE
refactor: remove isInitialContentHeightSet state in Dropdown

### DIFF
--- a/packages/vibrant-components/src/lib/Dropdown/Dropdown.tsx
+++ b/packages/vibrant-components/src/lib/Dropdown/Dropdown.tsx
@@ -137,7 +137,7 @@ export const Dropdown = withDropdownVariation(
       if (contentHeight !== undefined) {
         setVisible(true);
       }
-    }, [contentHeight, isMobile]);
+    }, [contentHeight]);
 
     useEffect(() => {
       if (!visible) {


### PR DESCRIPTION
-  isInitialContentHeightSet(초기 contentHeight가 셋팅되고 난 이후인지 상태 여부) state를 visible로 대체히여 사용
- 높이 바뀔 때 애니메이션 속도 다른 곳과 같이 200ms로 설정
- 모달의 최대 높이(viewport -120)에서 사용되는 상수(120) 변수로 설정 