### PR TITLE
fix: 스토리북에서 Pretendard JP 폰트를 사용할 수 있게 한다

### DIFF
--- a/.storybook/decorators/withVibrantProvider.tsx
+++ b/.storybook/decorators/withVibrantProvider.tsx
@@ -5,19 +5,19 @@ import { VibrantProvider } from '@vibrant-ui/core';
 const theme = {
   typographyWeight: {
     regular: {
-      fontFamily: 'Pretendard',
+      fontFamily: 'Pretendard, "Pretendard JP"',
       fontWeight: '400',
     },
     medium: {
-      fontFamily: 'Pretendard',
+      fontFamily: 'Pretendard, "Pretendard JP"',
       fontWeight: '500',
     },
     bold: {
-      fontFamily: 'Pretendard',
+      fontFamily: 'Pretendard, "Pretendard JP"',
       fontWeight: '700',
     },
     extraBold: {
-      fontFamily: 'Pretendard',
+      fontFamily: 'Pretendard, "Pretendard JP"',
       fontWeight: '800',
     },
   },


### PR DESCRIPTION
### before 
<img width="372" alt="image" src="https://user-images.githubusercontent.com/37496919/190951622-fae19ffa-4942-4e9f-b7e3-14d8ebce2496.png">

### after
<img width="362" alt="image" src="https://user-images.githubusercontent.com/37496919/190951540-cdc7f679-886c-4fef-a522-7568ad3a0b35.png">
