### PR TITLE
fix: SelectField QA 사항을 반영한다

### DIFF
--- a/packages/vibrant-components/src/lib/SelectField/SelectField.tsx
+++ b/packages/vibrant-components/src/lib/SelectField/SelectField.tsx
@@ -5,7 +5,6 @@ import { Icon } from '@vibrant-ui/icons';
 import { Body } from '../Body';
 import { HStack } from '../HStack';
 import { SelectOptionGroup } from '../SelectOptionGroup';
-import { Space } from '../Space';
 import { withSelectFieldVariation } from './SelectFieldProps';
 
 export const SelectField = withSelectFieldVariation(
@@ -200,9 +199,9 @@ export const SelectField = withSelectFieldVariation(
             {...restProps}
           >
             <HStack alignItems="center" width="100%">
-              <Box as="span" flex={1}>
+              <Box as="span" flex={1} pr={12}>
                 {selectedOption ? (
-                  <Box flexDirection={inlineLabel ? 'row' : 'column'}>
+                  <Box as="span" flexDirection={inlineLabel ? 'row' : 'column'}>
                     {Boolean(label) && (
                       <>
                         <Body
@@ -211,6 +210,10 @@ export const SelectField = withSelectFieldVariation(
                           lineLimit={1}
                           wordBreak="break-all"
                           wordWrap="break-word"
+                          flexGrow={0}
+                          flexShrink={0}
+                          flexBasis="auto"
+                          maxWidth="90%"
                         >
                           {label}
                         </Body>
@@ -243,7 +246,6 @@ export const SelectField = withSelectFieldVariation(
                   </Body>
                 )}
               </Box>
-              <Space width={12} />
               <Icon.ArrowTriangleDown.Regular
                 size={20}
                 fill={disabled ? 'onView3' : state === 'error' ? 'error' : 'onView1'}

--- a/packages/vibrant-core/src/lib/Text/TextProps.ts
+++ b/packages/vibrant-core/src/lib/Text/TextProps.ts
@@ -7,6 +7,7 @@ import type {
   DisplaySystemProps,
   FlexboxSystemProps,
   PositionSystemProps,
+  SizingSystemProps,
   SpacingSystemProps,
   TextSystemProps,
   TypographySystemProps,
@@ -16,6 +17,7 @@ import {
   displaySystemProps,
   flexboxSystemProps,
   positionSystemProps,
+  sizingSystemProps,
   spacingSystemProps,
   textSystemProps,
   typographySystemProps,
@@ -27,7 +29,8 @@ type SystemProps = ColorSystemProps &
   PositionSystemProps &
   SpacingSystemProps &
   TextSystemProps &
-  TypographySystemProps;
+  TypographySystemProps &
+  SizingSystemProps;
 
 export const systemProps = [
   ...colorSystemProps,
@@ -37,6 +40,7 @@ export const systemProps = [
   ...spacingSystemProps,
   ...textSystemProps,
   ...typographySystemProps,
+  ...sizingSystemProps,
 ];
 
 export const systemPropNames = systemProps


### PR DESCRIPTION
### inlineLabel = false 이고 value가 존재할 때 label의 텍스트 크기가 body level 6으로 수정

| Before                                                                            | After                                                                            |
| --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| ![Before_1](https://user-images.githubusercontent.com/37496919/191153735-82c866bc-027c-479b-8f5a-a3869899e289.png) | ![placeholder](https://user-images.githubusercontent.com/37496919/191154132-b926a9c6-6e36-4568-b77f-6fcb346ff7bc.png) |

### label이 없고 placeholder만 노출 될 경우 state = error일 때 색상을 onView3으로 수정


| Before                                                                            | After                                                                            |
| --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| ![Before_1](https://user-images.githubusercontent.com/37496919/191154713-fb1f5f28-2a6b-4838-aa53-e5b28a051a9a.png) | ![placeholder](https://user-images.githubusercontent.com/37496919/191154525-7477576c-6b1c-40b8-b174-63b3c34af271.png) |

### inlineLabel = true이고 label도 길고 value도 길 때 
label이 input의 9/10 너비 안에 들어가는 너비를 가지고 있으면 label을 모두 보여준 후 나머지 너비를 value로 표시하고 
label이 Input의 9/10을 초과하는 너비를 가지고 있으면 9/10 너비로 ellipsis되고 나머지 너비를 value가 표시할 수 있게 해줍니다.

- label이 9/10 너비를 넘어가는 경우 
<img width="351" alt="image" src="https://user-images.githubusercontent.com/37496919/191154952-5fc506e1-6b45-4f70-a8b6-15a2ea786bef.png">

- label이 9/10 너비 안에 들어가는 경우
<img width="340" alt="image" src="https://user-images.githubusercontent.com/37496919/191154989-417fef8c-e6e3-4ab8-93b5-7e098fb5ae21.png">

