### PR TITLE
fix: lineLimit이 1일 때 webKitLineClamp 속성을 사용하지 않는다

### DIFF
--- a/packages/vibrant-components/src/lib/FieldLayout/FieldLayout.tsx
+++ b/packages/vibrant-components/src/lib/FieldLayout/FieldLayout.tsx
@@ -55,7 +55,6 @@ export const FieldLayout = withFieldLayoutVariation(
                 right={renderEnd ? 12 : 15}
                 color={textColor}
                 lineLimit={1}
-                wordBreak="break-all"
               >
                 {label}
               </Text>

--- a/packages/vibrant-components/src/lib/SelectField/SelectField.tsx
+++ b/packages/vibrant-components/src/lib/SelectField/SelectField.tsx
@@ -199,7 +199,7 @@ export const SelectField = withSelectFieldVariation(
             {...restProps}
           >
             <HStack alignItems="center" width="100%">
-              <Box as="span" flex={1} pr={12}>
+              <Box as="span" flex={1} pr={12} minWidth={0}>
                 {selectedOption ? (
                   <Box as="span" flexDirection={inlineLabel ? 'row' : 'column'}>
                     {Boolean(label) && (
@@ -208,8 +208,6 @@ export const SelectField = withSelectFieldVariation(
                           level={inlineLabel ? 2 : 6}
                           color={labelColor}
                           lineLimit={1}
-                          wordBreak="break-all"
-                          wordWrap="break-word"
                           flexGrow={0}
                           flexShrink={0}
                           flexBasis="auto"
@@ -224,13 +222,7 @@ export const SelectField = withSelectFieldVariation(
                         </Box>
                       </>
                     )}
-                    <Body
-                      level={2}
-                      color={disabled ? 'onView3' : 'onView1'}
-                      wordBreak="break-all"
-                      wordWrap="break-word"
-                      lineLimit={1}
-                    >
+                    <Body level={2} color={disabled ? 'onView3' : 'onView1'} lineLimit={1}>
                       {selectedOption.label}
                     </Body>
                   </Box>

--- a/packages/vibrant-core/src/lib/props/text/text.ts
+++ b/packages/vibrant-core/src/lib/props/text/text.ts
@@ -26,13 +26,20 @@ const wordWrapProp = createSystemProp({
 
 const lineLimitProp = createSystemProp({
   property: 'lineLimit',
-  transform: (value: number) => ({
-    display: '-webkit-box',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    WebkitBoxOrient: 'vertical',
-    WebkitLineClamp: value,
-  }),
+  transform: (value: number) =>
+    value > 1
+      ? {
+          display: '-webkit-box',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          WebkitBoxOrient: 'vertical',
+          WebkitLineClamp: value,
+        }
+      : {
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+        },
 });
 
 export const textSystemProps = [


### PR DESCRIPTION
[safari에서 `-webkit-line-clamp` 속성을 적용되어 글씨가 잘렸을 때 `line-height`가 정확하게 동작하지 않는 이슈](https://bugs.webkit.org/show_bug.cgi?id=187938)가 있어 `lineLimit`이 `1`인 경우 `webkit-line-clamp`을 사용하지 않고 `white-space: nowrap`을 사용하도록 구현합니다. (`lineLimit`이 2 이상인 경우에는 노운 이슈로 가져가는 것으로 ..)
- 스크린샷은 `line-height: 18px` 적용한 경우 

| Before                                                                            | After                                                                            |
| --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| ![Before_1](https://user-images.githubusercontent.com/37496919/191201531-ec677486-a197-42b6-8d27-f631aa4b5e9d.png) | ![After_1](https://user-images.githubusercontent.com/37496919/191216993-46edbbd0-1cc3-414e-afd3-e662e1130070.png) |
