### PR TITLE
fix: fix Expo prebuild failure

### DIFF
--- a/packages/vibrant-example-app/package.json
+++ b/packages/vibrant-example-app/package.json
@@ -41,6 +41,7 @@
     "uuid": "*"
   },
   "scripts": {
-    "eas-build-pre-install": "cd ../../ && cp yarn.lock ./packages/vibrant-example-app/"
+    "eas-build-pre-install": "cd ../../ && cp yarn.lock ./packages/vibrant-example-app/",
+    "expo": "npx expo"
   }
 }


### PR DESCRIPTION
expo-cli를 추가해줬는데 다시 prebuild 실패가 발생하고 있어서 해결했습니다.
왜인지는 모르겠지만 자꾸 expo를 script에서 찾고 있어서 스크립트를 추가해 줬습니다.
제 예상으로는 저희가 모노레포를 사용하고 있기 때문에 발생하고 있는 이슈로 보입니다.

### Before

<img width="1240" alt="image" src="https://user-images.githubusercontent.com/50603255/192919995-76360774-761f-4446-836f-7df4ab31b960.png">


### After

<img width="1273" alt="image" src="https://user-images.githubusercontent.com/50603255/192920004-2f9fd664-28f2-4ae4-b9a0-1f4665de16a5.png">
