### PR TITLE
chore: expo-updates 테스트를 위해 CI를 임시로 막는다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,13 +67,13 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_TOKEN }}
           autoAcceptChanges: true
 
-  expo:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v1
-      - run: yarn
-      - name: Update Vibrant Example App
-        run: yarn nx update vibrant-example-app --branch preview
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+  # expo:
+  #   runs-on: ubuntu-latest
+  #   if: github.ref == 'refs/heads/main'
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - run: yarn
+  #     - name: Update Vibrant Example App
+  #       run: yarn nx update vibrant-example-app --branch preview
+  #       env:
+  #         EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}


### PR DESCRIPTION
<img width="537" alt="image" src="https://user-images.githubusercontent.com/50603255/192921938-1f3acceb-90ed-46b1-8328-052c3ef1420d.png">

이 PR이 머지되면 main 브랜치에서 CI / expo가 돌지 않게 됩니다.