### PR TITLE
feat: update storyFn into StoryFn components in storybook decorators

### DIFF
--- a/.storybook/decorators/withAppetize.tsx
+++ b/.storybook/decorators/withAppetize.tsx
@@ -3,18 +3,18 @@ import { DeepLinkRenderer } from '@storybook/native-components';
 import type { DecoratorFn } from '@storybook/react';
 import { HStack, Paper, Title, VStack } from '@vibrant-ui/components';
 
-export const withAppetize: DecoratorFn = (storyFn, context) => {
+export const withAppetize: DecoratorFn = (StoryFn, context) => {
   const { platform } = context.globals;
 
   if (platform === 'web') {
-    return <>{storyFn()}</>;
+    return <StoryFn />;
   }
 
   return (
     <HStack>
       <Global styles={appetizeIframeStyle} />
       <Paper width="50%" minHeight="100vh" backgroundColor="background">
-        {storyFn()}
+        <StoryFn />
       </Paper>
       <Paper width="50%" minHeight="100vh">
         <VStack>

--- a/.storybook/decorators/withGlobalStyle.tsx
+++ b/.storybook/decorators/withGlobalStyle.tsx
@@ -1,9 +1,9 @@
 import type { DecoratorFn } from '@storybook/react';
 import { GlobalStyle } from '@vibrant-ui/components';
 
-export const withGlobalStyle: DecoratorFn = storyFn => (
+export const withGlobalStyle: DecoratorFn = StoryFn => (
   <>
     <GlobalStyle />
-    {storyFn()}
+    <StoryFn />
   </>
 );

--- a/.storybook/decorators/withTheme.tsx
+++ b/.storybook/decorators/withTheme.tsx
@@ -2,7 +2,7 @@ import type { DecoratorFn } from '@storybook/react';
 import { HStack } from '@vibrant-ui/components';
 import { Box, ThemeProvider } from '@vibrant-ui/core';
 
-export const withTheme: DecoratorFn = (storyFn, context) => {
+export const withTheme: DecoratorFn = (StoryFn, context) => {
   const { theme } = context.globals;
 
   if (theme === 'side-by-side') {
@@ -10,12 +10,12 @@ export const withTheme: DecoratorFn = (storyFn, context) => {
       <HStack>
         <ThemeProvider theme={{ mode: 'light' }} root={true}>
           <Box position="relative" alignItems="start" width="50%" minHeight="100vh" backgroundColor="background">
-            {storyFn()}
+            <StoryFn />
           </Box>
         </ThemeProvider>
         <ThemeProvider theme={{ mode: 'dark' }} root={true}>
           <Box position="relative" alignItems="start" width="50%" minHeight="100vh" backgroundColor="background">
-            {storyFn()}
+            <StoryFn />
           </Box>
         </ThemeProvider>
       </HStack>
@@ -25,7 +25,7 @@ export const withTheme: DecoratorFn = (storyFn, context) => {
   return (
     <ThemeProvider theme={{ mode: theme }} root={true}>
       <Box position="relative" alignItems="start" width="100%" minHeight="100vh" backgroundColor="background">
-        {storyFn()}
+        <StoryFn />
       </Box>
     </ThemeProvider>
   );

--- a/.storybook/decorators/withVibrantProvider.tsx
+++ b/.storybook/decorators/withVibrantProvider.tsx
@@ -23,7 +23,7 @@ const theme = {
   },
 };
 
-export const withVibrantProvider: DecoratorFn = storyFn => (
+export const withVibrantProvider: DecoratorFn = StoryFn => (
   <VibrantProvider
     theme={theme}
     dependencies={{
@@ -31,6 +31,6 @@ export const withVibrantProvider: DecoratorFn = storyFn => (
     }}
     portalBottomPriorityOrder={['bottom-bar', 'floating-action-button']}
   >
-    {storyFn()}
+    <StoryFn />
   </VibrantProvider>
 );


### PR DESCRIPTION
*onView1 의 hex 컬러가 잘 반영되어 보임을 확인하세용!

**Before**
<img width="986" alt="스크린샷 2022-10-05 오후 3 45 24" src="https://user-images.githubusercontent.com/105209178/193998162-4bacd98c-6eaf-4082-9b88-f2ddfb66c6e1.png">

**After**
<img width="979" alt="스크린샷 2022-10-05 오후 3 46 09" src="https://user-images.githubusercontent.com/105209178/193998177-e4585611-f33b-480d-9f55-69e78498b710.png">
