### PR TITLE
fix: baseComponent로 받는 타입에서 onLayout은 사용하지 않도록 한다

### DIFF
--- a/packages/vibrant-core/src/lib/Box/BoxProps.ts
+++ b/packages/vibrant-core/src/lib/Box/BoxProps.ts
@@ -132,7 +132,7 @@ export type BoxProps<
           ref?: Ref<HTMLElement>;
           children?: ReactElementChildren;
         }
-      : ComponentProps<BaseComponent>,
+      : Omit<ComponentProps<BaseComponent>, 'onLayout'>,
     keyof SystemProps
   >;
 


### PR DESCRIPTION

## Before

<img width="1161" alt="image" src="https://user-images.githubusercontent.com/32216112/195766296-bfff5371-8812-4217-acd7-83475aceacff.png">


## After

<img width="622" alt="image" src="https://user-images.githubusercontent.com/32216112/195766269-50df9aa5-ac15-4209-9a53-53ce2b48c431.png">

