### PR TITLE
fix: updates TextChildren props types

### DIFF
--- a/packages/vibrant-core/src/lib/Text/TextProps.ts
+++ b/packages/vibrant-core/src/lib/Text/TextProps.ts
@@ -49,7 +49,7 @@ export const systemPropNames = systemProps
 
 export type TextElements = 'br' | 'h1' | 'h2' | 'h3' | 'h5' | 'h6' | 'label' | 'p' | 'span';
 
-export type TextChildren = ReactElementChild | ReactElementChild[] | ReactTextChild | ReactTextChild[];
+export type TextChildren = ReactElementChild | ReactTextChild | TextChildren[];
 
 export type TextProps = SystemProps & {
   as?: TextElements;


### PR DESCRIPTION
**Before**
<img width="1216" alt="스크린샷 2022-10-17 오후 2 48 35" src="https://user-images.githubusercontent.com/105209178/196098769-2b207bca-8ae5-4171-85e7-c34ad5fd2d60.png">

**After**
<img width="1199" alt="스크린샷 2022-10-17 오후 2 48 53" src="https://user-images.githubusercontent.com/105209178/196098807-628c9e22-1960-4557-9f8b-884817527f7a.png">
