### PR TITLE
fix: TabGroup에서 탭 이동 시 첫번째 아이템으로 스크롤되는 이슈를 수정한다. 

### DIFF
--- a/packages/vibrant-components/src/lib/TabGroup/TabGroup.tsx
+++ b/packages/vibrant-components/src/lib/TabGroup/TabGroup.tsx
@@ -41,17 +41,17 @@ export const TabGroup = withTabGroupVariation(
               flexBasis={tabFlexBasis}
               hidden={element.props.hidden}
               key={element.props.id}
+              ref={(domRef: HTMLElement | null) => {
+                if (!domRef) {
+                  return;
+                }
+
+                tabRefs.current[element.props.id] = domRef;
+              }}
             >
               {cloneElement(element, {
                 active: element.props.id === tabId,
                 onClick: onTabChange,
-                ref: (domRef: HTMLElement | null) => {
-                  if (!domRef) {
-                    return;
-                  }
-
-                  tabRefs.current[element.props.id] = domRef;
-                },
               })}
             </HStack>
           ))}


### PR DESCRIPTION
offsetLeft를 사용하여 스크롤 위치를 계산하고 있었는데 offsetLeft는 offsetParent(가장 가까운 positioend 조상)에 상대적인 값이라 모든 요소가 relative position을 가지면서 의도한 대로 동작하지 않게 된 것으로 추정됩니다 .. 그래서 ref 위치를 컨테이너 바로 하위 요소인 HStack에 적용하게 수정했습니다

### before

https://user-images.githubusercontent.com/37496919/196115881-db47d5b1-783d-40ab-ab17-58181f0444b3.mov


### after

https://user-images.githubusercontent.com/37496919/196115869-dfb9f7b2-2aeb-4335-9bcc-dc5dc89294f4.mov

