### PR TITLE
fix: jest.config.ts에 vibrant-core를 플랫폼별로 분기한다

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,10 +1,8 @@
 import { getJestProjects } from '@nrwl/jest';
 
-let projects = getJestProjects();
-
-projects = projects.filter(project => !project.includes('vibrant-core'));
-
-projects = projects.concat('packages/vibrant-core/jest.config.web.ts', 'packages/vibrant-core/jest.config.native.ts');
+const projects = getJestProjects()
+  .filter(project => !project.includes('vibrant-core'))
+  .concat('packages/vibrant-core/jest.config.web.ts', 'packages/vibrant-core/jest.config.native.ts');
 
 export default {
   projects,


### PR DESCRIPTION
### Before
<img width="894" alt="image" src="https://user-images.githubusercontent.com/32216112/197432283-24f946b2-4778-46f4-a96c-abb4ce625f33.png">


### After

<img width="705" alt="image" src="https://user-images.githubusercontent.com/32216112/197432206-f4cfed56-6fba-4772-b112-07818c6b4e3e.png">
