### PR TITLE
fix: set tablet bp Toast width to content-fit

### DIFF
--- a/packages/vibrant-components/src/lib/Toast/Toast.tsx
+++ b/packages/vibrant-components/src/lib/Toast/Toast.tsx
@@ -14,9 +14,9 @@ export const Toast = withToastVariation(
         backgroundColor="inverseSurface"
         elevationLevel={1}
         maxWidth={816}
-        width={['100%', '100%', 'auto']}
+        width={['100%', 'auto']}
       >
-        <HStack px={16} py={12} alignVertical="center" width={['100%', '100%', 'auto']}>
+        <HStack px={16} py={12} alignVertical="center" width={['100%', 'auto']}>
           {IconComponent && (
             <VStack mr={8} flexShrink={0}>
               <IconComponent size={18} fill={color} />


### PR DESCRIPTION
## Before
<img width="1027" alt="스크린샷 2022-10-27 오후 5 43 23" src="https://user-images.githubusercontent.com/33626219/198239606-75258793-2fcd-4a80-becf-f7681fceb31d.png">

## After
<img width="1027" alt="스크린샷 2022-10-27 오후 5 45 04" src="https://user-images.githubusercontent.com/33626219/198239614-f892bbd7-9dd3-4255-a21a-87052f140e85.png">
