### PR TITLE
fix: OverlayBox에서 자식 요소 클릭 시 onDismiss가 호출되지 않도록 한다.

### DIFF
--- a/packages/vibrant-core/src/lib/OverlayBox/OverlayBox.tsx
+++ b/packages/vibrant-core/src/lib/OverlayBox/OverlayBox.tsx
@@ -55,7 +55,7 @@ export const OverlayBox = withOverlayBoxVariation(
           height={targetRect.height}
           onClick={handleTargetClick}
         >
-          <Box position="absolute" ref={innerRef} zIndex={1} {...boxProps}>
+          <Box position="absolute" ref={innerRef} {...boxProps}>
             {children}
           </Box>
         </Box>


### PR DESCRIPTION
https://user-images.githubusercontent.com/37496919/198990405-b5e0160b-dda8-4379-9b3b-29a06b0e53a3.mov

OverlayBox children으로 클릭 가능한 요소가 있을 때 이벤트가 전파되어 onDismiss가 호출되는 문제가 있어서 이벤트가 발생한 것이 이벤트를 등록한 요소일 때(`event.target === event.currentTarget`)만 닫히도록 조건을 추가해줬습니다.
(원래 저렇게 구현됐던 이유는 PressableBox에서 기본적으로 stopPropagation을 해주기 때문이었는데 외부에서 사용할 때 vibrant의 PressableBox를 사용하지 않을 수 있다는 것을 고려하지 못했습니다 ..(