### PR TITLE
fix: set display block when lineLimit is 1

### DIFF
--- a/packages/vibrant-components/src/lib/Body/Body.stories.tsx
+++ b/packages/vibrant-components/src/lib/Body/Body.stories.tsx
@@ -10,4 +10,4 @@ export default {
   },
 } as ComponentMeta<typeof Body>;
 
-export const Basic: ComponentStory<typeof Body> = props => <Body {...props} />;
+export const Basic: ComponentStory<typeof Body> = props => <Body width="100%" {...props} />;

--- a/packages/vibrant-core/src/lib/props/text/text.ts
+++ b/packages/vibrant-core/src/lib/props/text/text.ts
@@ -40,6 +40,7 @@ const lineLimitProp = createSystemProp({
           WebkitLineClamp: value,
         }
       : {
+          display: 'block',
           overflow: 'hidden',
           whiteSpace: 'nowrap',
           textOverflow: 'ellipsis',


### PR DESCRIPTION
text-overflow 속성이 block 컨테이너에서만 동작을 하기 때문에 web에서는 lineLimit을 사용한 경우 display block이 되도록 했습니다. 

### before
<img width="378" alt="image" src="https://user-images.githubusercontent.com/37496919/199436592-b0b207e4-a4c7-420e-b159-2fb95fc55750.png">

### after
<img width="406" alt="image" src="https://user-images.githubusercontent.com/37496919/199436483-319b6661-ffcb-4cb4-84d4-4e1fc8b90396.png">
