### PR TITLE
fix: safeAreaMode가 margin일 때 padding이 적용되는 문제를 해결한다

### DIFF
--- a/packages/vibrant-components/src/lib/StackedPortal/StackedPortal.tsx
+++ b/packages/vibrant-components/src/lib/StackedPortal/StackedPortal.tsx
@@ -17,12 +17,21 @@ export const StackedPortal = withStackedPortalVariation(
       position: currentPosition,
       id,
       order,
-      offset: safeAreaMode !== 'padding' ? currentPositionOffset : 0,
+      offset: safeAreaMode === 'margin' ? currentPositionOffset : 0,
       safeAreaInset: safeAreaMode === 'margin',
     });
 
     const paddingStyle = useMemo(() => {
-      if (safeAreaMode !== 'padding' || renderedIndex !== 1) {
+      if (safeAreaMode === 'margin') {
+        return {
+          pt: 0,
+          pl: 0,
+          pr: 0,
+          pb: 0,
+        };
+      }
+
+      if (renderedIndex !== 1) {
         return {
           pt: 0,
           pl: 0,


### PR DESCRIPTION
## Before
<img width="451" alt="image" src="https://user-images.githubusercontent.com/33626219/200479299-2a75b74b-bfbc-48a1-8010-83d9ef1bb1fa.png">

## After
<img width="451" alt="image" src="https://user-images.githubusercontent.com/33626219/200479309-b83d6d10-7ef5-4e85-ac6f-1ed1bc74a6e3.png">
