### PR TITLE
feat: pass customOpenerRef to renderOpener args

### DIFF
--- a/packages/vibrant-components/src/lib/Dropdown/Dropdown.stories.tsx
+++ b/packages/vibrant-components/src/lib/Dropdown/Dropdown.stories.tsx
@@ -3,6 +3,7 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import { Box } from '@vibrant-ui/core';
 import { Icon } from '@vibrant-ui/icons';
 import { Body } from '../Body';
+import { FloatingActionButton } from '../FloatingActionButton';
 import { HStack } from '../HStack';
 import { Pressable } from '../Pressable';
 import { Title } from '../Title';
@@ -15,7 +16,7 @@ const DropdownContent = () => {
   return opened ? (
     <VStack spacing={20} px={20}>
       <Pressable onClick={() => setOpened(false)}>
-        <HStack alignItems="center" spacing={4}>
+        <HStack alignVertical="center" spacing={4}>
           <Icon.ChevronLeft.Regular size={16} />
           <Title level={6}>화질</Title>
         </HStack>
@@ -27,14 +28,14 @@ const DropdownContent = () => {
   ) : (
     <VStack spacing={20}>
       <Pressable onClick={() => setOpened(true)}>
-        <HStack px={20} alignHorizontal="space-between" alignItems="flex-end">
+        <HStack px={20} alignHorizontal="space-between" alignVertical="end">
           <Body level={2}>화질</Body>
           <Body level={3} color="onView2">
             1080p
           </Body>
         </HStack>
       </Pressable>
-      <HStack px={20} alignHorizontal="space-between" alignItems="flex-end">
+      <HStack px={20} alignHorizontal="space-between" alignVertical="end">
         <Body level={2}>자동 재생</Body>
         <Body level={3} color="onView2">
           켜짐
@@ -81,6 +82,20 @@ export const WithLongContent: ComponentStory<typeof Dropdown> = props => (
               </Body>
             ))}
           </>
+        )}
+      />
+    </Box>
+  </VStack>
+);
+
+export const WithFloatingActionButton: ComponentStory<typeof Dropdown> = props => (
+  <VStack width="100%">
+    <Box mx="auto">
+      <Dropdown
+        {...props}
+        position="top-end"
+        renderOpener={({ ref, open }) => (
+          <FloatingActionButton ref={ref} IconComponent={Icon.ArrowUpToLine.Thin} onClick={open} />
         )}
       />
     </Box>

--- a/packages/vibrant-components/src/lib/Dropdown/Dropdown.tsx
+++ b/packages/vibrant-components/src/lib/Dropdown/Dropdown.tsx
@@ -70,6 +70,7 @@ const getOffsetAvoidingOverflowByPosition = (
 export const Dropdown = withDropdownVariation(
   ({ open, renderOpener, renderContents, position = 'bottom', spacing = 8, onClose }) => {
     const openerRef = useRef<HTMLElement>(null);
+    const customOpenerRef = useRef<HTMLElement>(null);
     const [isOpen, setIsOpen] = useState(open);
     const [visible, setVisible] = useState(false);
     const [offset, setOffset] = useState<{ x?: number; y?: number }>({});
@@ -97,7 +98,10 @@ export const Dropdown = withDropdownVariation(
 
     useLockBodyScroll(isOpen || visible);
 
-    const opener = useMemo(() => renderOpener({ open: () => setIsOpen(!isOpen), isOpen }), [isOpen, renderOpener]);
+    const opener = useMemo(
+      () => renderOpener({ open: () => setIsOpen(!isOpen), isOpen, ref: customOpenerRef }),
+      [isOpen, renderOpener]
+    );
 
     const closeDropdown = useCallback(() => {
       setIsOpen(false);
@@ -108,7 +112,7 @@ export const Dropdown = withDropdownVariation(
     const handleContentResize = useCallback(
       async ({ width, height, top, left }: LayoutEvent) => {
         if (!isMobile) {
-          const openerRect = await getElementRect(openerRef.current);
+          const openerRect = await getElementRect(customOpenerRef.current ?? openerRef.current);
 
           const { x: offsetX, y: offsetY } = getOffsetAvoidingOverflowByPosition(
             openerRect,
@@ -173,7 +177,12 @@ export const Dropdown = withDropdownVariation(
               }}
               duration={200}
             >
-              <OverlayBox open={isOpen} onDismiss={closeDropdown} targetRef={openerRef} zIndex={zIndex.dropdown}>
+              <OverlayBox
+                open={isOpen}
+                onDismiss={closeDropdown}
+                targetRef={customOpenerRef.current ? customOpenerRef : openerRef}
+                zIndex={zIndex.dropdown}
+              >
                 <Box
                   backgroundColor="surface2"
                   py={CONTENT_PADDING}

--- a/packages/vibrant-components/src/lib/Dropdown/DropdownProps.ts
+++ b/packages/vibrant-components/src/lib/Dropdown/DropdownProps.ts
@@ -1,3 +1,4 @@
+import type { RefObject } from 'react';
 import type { ReactElementChild } from '@vibrant-ui/core';
 import { withVariation } from '@vibrant-ui/core';
 import type { Position } from '@vibrant-ui/utils';
@@ -5,7 +6,7 @@ import type { Position } from '@vibrant-ui/utils';
 export type DropdownProps = {
   position?: Position;
   renderContents: (_: { close: () => void }) => ReactElementChild;
-  renderOpener: (_: { open: () => void; isOpen: boolean }) => ReactElementChild;
+  renderOpener: (_: { open: () => void; isOpen: boolean; ref: RefObject<any> }) => ReactElementChild;
   spacing?: number;
   open: boolean;
   onClose?: () => void;


### PR DESCRIPTION
<img width="325" alt="image" src="https://user-images.githubusercontent.com/37496919/201097373-3676af07-0f53-430c-9086-3b7d364875bc.png">

FAB 버튼 기준으로도 dropdown이 뜰 수 있도록 지원하기 위해 커스텀한 opener의 ref를 설정할 수 있도록 renderOpener 파라미터로 customOpenerRef를 넘겨줍니다. 위치 계산할 때 customOpenerRef > 기존 openrRef 순으로 선택하여 계산됩니다.