### PR TITLE
feat: include transparent into BaseColorToken

### DIFF
--- a/packages/vibrant-theme/src/types/Colors.ts
+++ b/packages/vibrant-theme/src/types/Colors.ts
@@ -57,7 +57,7 @@ export const colorTokens = [
 export type ColorToken = typeof colorTokens[number];
 export type BaseColorToken = Exclude<
   ColorToken,
-  'black' | 'dim' | 'overlay' | 'transparent' | 'white' | `on${string}` | `outline${string}`
+  'black' | 'dim' | 'overlay' | 'white' | `on${string}` | `outline${string}`
 >;
 export type OnColorToken = Exclude<Extract<ColorToken, `on${string}`>, 'onColor'>;
 
@@ -97,4 +97,5 @@ export const BaseColorOnColorMap: { [color in BaseColorToken]: OnColorToken } = 
   disable: 'onView3',
   background: 'onView1',
   inverseSurface: 'onInverseSurface',
+  transparent: 'onView1',
 };


### PR DESCRIPTION
Before
<img width="796" alt="스크린샷 2022-11-22 오후 4 31 12" src="https://user-images.githubusercontent.com/105209178/203252290-8c0bc09a-5fcf-40af-a864-0777c694ec88.png">

After
<img width="706" alt="스크린샷 2022-11-22 오후 4 31 06" src="https://user-images.githubusercontent.com/105209178/203252305-0340a891-5b24-45b5-b6b3-ffe0a8ea32a2.png">
