### PR TITLE
fix: don't invoke onValueChange when first rendering with defaultValue

### DIFF
--- a/packages/vibrant-components/src/lib/SelectField/SelectField.tsx
+++ b/packages/vibrant-components/src/lib/SelectField/SelectField.tsx
@@ -115,7 +115,7 @@ export const SelectField = withSelectFieldVariation(
       handleValueChange?.(selectedOption.value);
 
       prevSelectedValueRef.current = selectedOption?.value;
-    }, [handleValueChange, selectedOption.value]);
+    }, [handleValueChange, selectedOption?.value]);
 
     useEffect(() => {
       setState(stateProp);


### PR DESCRIPTION
### before
<img width="1057" alt="image" src="https://user-images.githubusercontent.com/37496919/203729706-954d7702-722c-477e-b68f-fcefe8501668.png">


### after
<img width="800" alt="image" src="https://user-images.githubusercontent.com/37496919/203729534-eaa73182-89c9-48ad-ab46-bf87c93273db.png">
