### PR TITLE
feat: update scrolldetector return scrollposition

### DIFF
--- a/packages/vibrant-components/src/lib/ScrollDetector/ScrollDetector.stories.tsx
+++ b/packages/vibrant-components/src/lib/ScrollDetector/ScrollDetector.stories.tsx
@@ -15,7 +15,7 @@ export const Basic: ComponentStory<typeof ScrollDetector> = () => (
   <Paper backgroundColor="background" width="100%" height="100%">
     <VStack alignHorizontal="center" spacing={20}>
       <ScrollDetector>
-        {({ scrollDirection }) => (
+        {({ scrollDirection, scrollPosition }) => (
           <Box
             alignItems="center"
             justifyContent="center"
@@ -24,6 +24,7 @@ export const Basic: ComponentStory<typeof ScrollDetector> = () => (
             backgroundColor={scrollDirection === 'up' ? 'informative' : 'warning'}
           >
             <Body level={1}>{`${scrollDirection === 'down' ? 'Down' : 'Up'}`}</Body>
+            <Body level={1}>{scrollPosition}</Body>
           </Box>
         )}
       </ScrollDetector>

--- a/packages/vibrant-components/src/lib/ScrollDetector/ScrollDetector.tsx
+++ b/packages/vibrant-components/src/lib/ScrollDetector/ScrollDetector.tsx
@@ -1,15 +1,22 @@
 import type { ReactElement } from 'react';
+import { useEffect, useState } from 'react';
 import { useScroll } from '@vibrant-ui/core';
-import type { EventListenerCallback, ScrollDirection } from '@vibrant-ui/core';
+import type { ScrollDirection } from '@vibrant-ui/core';
 type ScrollDetectorProps = {
-  children: (_: {
-    scrollDirection: ScrollDirection;
-    addEventListener: (callback: EventListenerCallback) => void;
-  }) => ReactElement;
+  children: (_: { scrollDirection: ScrollDirection; scrollPosition: number }) => ReactElement;
 };
 
 export const ScrollDetector = ({ children }: ScrollDetectorProps) => {
+  const [scrollPosition, setScrollPosition] = useState(0);
   const { scrollDirection, addEventListener } = useScroll();
 
-  return children ? children({ scrollDirection, addEventListener }) : null;
+  useEffect(() => {
+    const cleanEventListener = addEventListener(({ scrollPosition }) => {
+      setScrollPosition(scrollPosition);
+    });
+
+    return cleanEventListener;
+  }, [addEventListener]);
+
+  return children ? children({ scrollDirection, scrollPosition }) : null;
 };


### PR DESCRIPTION
- 이벤트 리스너를 직접 리턴하는 대신, ScrollDetector 가 scrollPosition 을 리턴하게끔 수정했습니다.

https://user-images.githubusercontent.com/105209178/204451334-6c07c731-2ec6-4c63-977a-5940b9c2b5c7.mov

