### PR TITLE
chore: replace extchildren type with string in Storybook control

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -101,6 +101,11 @@ const config: StorybookViteConfig & {
           }
         }
 
+        // Replace TextChildren type with string
+        if (prop.type.raw === 'TextChildren') {
+          prop.type.name = 'string';
+        }
+
         return true;
       },
     },


### PR DESCRIPTION
기존의 TextChildren 타입을 갖고 있던 필드는 스토리북으로 테스트용 텍스트를 입력할 수 없는 환경이라 타입을 string으로 변경해주었습니다. 
### before
<img width="1209" alt="image" src="https://user-images.githubusercontent.com/37496919/205592234-a776627c-7f56-4ec9-8099-585f56c02d43.png">

### after
<img width="782" alt="image" src="https://user-images.githubusercontent.com/37496919/205592796-190366ad-9630-4cbd-bb2b-1814294fd02d.png">
