### PR TITLE
chore: open all border-related props in Paper except for the outline props

### DIFF
--- a/packages/vibrant-components/src/lib/Paper/PaperProps.ts
+++ b/packages/vibrant-components/src/lib/Paper/PaperProps.ts
@@ -16,7 +16,7 @@ import type {
 import { withVariation } from '@vibrant-ui/core';
 import type { BaseColorToken, GradientKind } from '@vibrant-ui/theme';
 
-type PaperProps = Pick<BorderSystemProps, 'borderColor' | 'borderRadiusLevel' | 'borderStyle' | 'borderWidth'> &
+type PaperProps = Omit<BorderSystemProps, 'outlineColor' | 'outlineOffset' | 'outlineStyle' | 'outlineWidth'> &
   DisplaySystemProps &
   SpacingSystemProps &
   InteractionSystemProps &


### PR DESCRIPTION
<img width="983" alt="Screen Shot 2022-12-05 at 8 05 04 PM" src="https://user-images.githubusercontent.com/8934513/205623360-f078cf14-4d61-4bb4-aa53-8018a2ccbdea.png">

- RN을 고려해 outline 관련 속성 외에 border 관련 속성을 모두 열어뒀습니다.