### PR TITLE
docs: ModalBottomSheet 문서의 잘못된 예제를 수정한다

### DIFF
--- a/packages/vibrant-website/docs/components/vibrant-component/modal-bottom-sheet.mdx
+++ b/packages/vibrant-website/docs/components/vibrant-component/modal-bottom-sheet.mdx
@@ -12,8 +12,11 @@ title: ModalBottomSheet
   title="오늘도 수강 완료!"
   subtitle="원하는 시간에 꾸준히 수강할 수 있도록 알림을 보내드릴게요!"
   primaryButtonText="확인"
-  onPrimaryButtonClick={({ close }) => {
-    close();
+  primaryButtonOptions={{
+    text: '확인',
+    onClick: ({ close }) => {
+      close();
+    },
   }}
   renderOpener={({ open }) => (
     <Pressable onClick={open}>열기</Pressable>


### PR DESCRIPTION
바뀌기 이전의 잘못된 API로 예제가 되어 있어 수정해줬습니다.

<img width="936" alt="image" src="https://user-images.githubusercontent.com/37496919/205829656-30ec4a51-ccc9-47c7-b00c-cf6b453c096a.png">
