### PR TITLE
fix: change Dropdown default width to minimum width

### DIFF
--- a/packages/vibrant-components/src/lib/Dropdown/Dropdown.stories.tsx
+++ b/packages/vibrant-components/src/lib/Dropdown/Dropdown.stories.tsx
@@ -71,6 +71,24 @@ export const Basic: ComponentStory<typeof Dropdown> = props => (
   </VStack>
 );
 
+export const WithLongWidth: ComponentStory<typeof Dropdown> = props => (
+  <VStack width="100%">
+    <Box mx="auto">
+      <Dropdown
+        {...props}
+        renderContents={() => (
+          <HStack width={400} px={20} alignHorizontal="space-between" alignVertical="end">
+            <Body level={2}>화질</Body>
+            <Body level={3} color="onView2">
+              1080p
+            </Body>
+          </HStack>
+        )}
+      />
+    </Box>
+  </VStack>
+);
+
 export const WithLongContent: ComponentStory<typeof Dropdown> = props => (
   <VStack width="100%">
     <Box mx="auto">

--- a/packages/vibrant-components/src/lib/Dropdown/Dropdown.tsx
+++ b/packages/vibrant-components/src/lib/Dropdown/Dropdown.tsx
@@ -188,7 +188,7 @@ export const Dropdown = withDropdownVariation(
                   py={CONTENT_PADDING}
                   elevationLevel={4}
                   borderRadiusLevel={1}
-                  width={[280, 280, 240]}
+                  minWidth={[280, 280, 240]}
                 >
                   <Transition
                     animation={


### PR DESCRIPTION
- Dropdown 컴포넌트의 width를 minWidth로 변경했습니다.
- 더 긴 너비를 원하면 콘텐츠 너비를 키우면 됩니다.

<img width="451" alt="Screen Shot 2022-12-15 at 9 23 23 PM" src="https://user-images.githubusercontent.com/8934513/207858651-4175189e-15f3-463a-9679-dee2f464cd2e.png">
