### PR TITLE
fix: restore scollBox native property

### DIFF
--- a/packages/vibrant-core/src/lib/ScrollBox/ScrollBox.native.tsx
+++ b/packages/vibrant-core/src/lib/ScrollBox/ScrollBox.native.tsx
@@ -32,7 +32,7 @@ export const ScrollBox = styled(
         style={restStyle}
         scrollEnabled={currentScrollEnabled}
         contentContainerStyle={{
-          flex: 1,
+          flexGrow: 1,
           flexDirection,
           alignItems,
           justifyContent,


### PR DESCRIPTION
Before
<img width="248" alt="스크린샷 2023-01-03 오후 4 55 16" src="https://user-images.githubusercontent.com/105209178/210318107-f119d59f-1bb0-4817-99b0-6c2538d564d9.png">


After
![Simulator Screen Shot - iPhone 13 - 2023-01-03 at 16 53 49](https://user-images.githubusercontent.com/105209178/210317978-accb1462-1cfb-46bb-8f3e-915d9e2d0727.png)
