### PR TITLE
fix: cannot read properties of null issue

### DIFF
--- a/packages/vibrant-components/src/lib/Tooltip/Tooltip.tsx
+++ b/packages/vibrant-components/src/lib/Tooltip/Tooltip.tsx
@@ -154,7 +154,9 @@ export const Tooltip = withTooltipVariation(
       (ref?: HTMLElement) => {
         targetRef.current = ref;
 
-        handleTooltipPosition();
+        if (ref) {
+          handleTooltipPosition();
+        }
       },
       [handleTooltipPosition]
     );


### PR DESCRIPTION
ref 가 없을때 getElementRect 가 호출되면서 발생하는 에러를 수정합니다.

<img width="1040" alt="스크린샷 2023-01-05 오후 5 58 50" src="https://user-images.githubusercontent.com/105209178/210741023-2afb8f84-3d52-4d88-8c0c-9b58b0be5caf.png">
