### PR TITLE
chore: allow ReactElement[] in children type of Table

### DIFF
--- a/packages/vibrant-components/src/lib/Table/Table.stories.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.stories.tsx
@@ -66,12 +66,13 @@ export const Basic: ComponentStory<typeof Table> = props => (
       />
       <Table.Column<Data> key="carbs" dataKey="carbs" title="carbs" />
       <Table.Column<Data> key="protein" dataKey="protein" title="protein" />
-      <Table.Column<Data>
-        key="Edit"
-        title=""
-        width={120}
-        renderDataCell={() => <OutlinedButton size="sm">삭제</OutlinedButton>}
-      />
+      {['Edit', 'Delete'].map(value => (
+        <Table.Column<Data>
+          key={value}
+          title=""
+          renderDataCell={() => <OutlinedButton size="sm">{value}</OutlinedButton>}
+        />
+      ))}
     </Table>
   </Box>
 );

--- a/packages/vibrant-components/src/lib/Table/TableProps.ts
+++ b/packages/vibrant-components/src/lib/Table/TableProps.ts
@@ -18,7 +18,7 @@ export type TableProps<Data extends Record<string, any>, RowKey extends keyof Da
   selectButtons?: { text: string; onClick: (selectedRows: Data[]) => void }[];
   onSelectionChange?: (selectedRowKeys: Data[RowKey][]) => void;
   renderExpanded?: (row: Data) => ReactElementChild;
-  children: (ReactElement<TableColumnProps<Data>> | boolean | null)[];
+  children: (ReactElement<TableColumnProps<Data>> | ReactElement<TableColumnProps<Data>>[] | boolean | null)[];
   onRow?: {
     onClick: (row: Data) => void;
   };


### PR DESCRIPTION
Table에서 배열 형태로 반환된 Table.Column 요소를 children 사용할 수 있게 타입을 수정했습니다.