### PR TITLE
chore: set maxWidth arg in Skeleton storybook

### DIFF
--- a/packages/vibrant-components/src/lib/Skeleton/Skeleton.stories.tsx
+++ b/packages/vibrant-components/src/lib/Skeleton/Skeleton.stories.tsx
@@ -6,6 +6,7 @@ export default {
   component: Skeleton,
   args: {
     width: '100%',
+    maxWidth: 200,
     height: 200,
     borderRadiusLevel: 2,
   },

--- a/packages/vibrant-components/src/lib/Skeleton/SkeletonButton/SkeletonButton.stories.tsx
+++ b/packages/vibrant-components/src/lib/Skeleton/SkeletonButton/SkeletonButton.stories.tsx
@@ -6,6 +6,7 @@ export default {
   component: SkeletonButton,
   args: {
     size: 'xl',
+    maxWidth: 200,
   },
 } as ComponentMeta<typeof SkeletonButton>;
 

--- a/packages/vibrant-components/src/lib/Skeleton/SkeletonChip/SkeletonChip.stories.tsx
+++ b/packages/vibrant-components/src/lib/Skeleton/SkeletonChip/SkeletonChip.stories.tsx
@@ -6,6 +6,7 @@ export default {
   component: SkeletonChip,
   args: {
     size: 'md',
+    maxWidth: 500,
   },
 } as ComponentMeta<typeof SkeletonChip>;
 

--- a/packages/vibrant-components/src/lib/Skeleton/SkeletonField/SkeletonField.stories.tsx
+++ b/packages/vibrant-components/src/lib/Skeleton/SkeletonField/SkeletonField.stories.tsx
@@ -6,6 +6,7 @@ export default {
   component: SkeletonField,
   args: {
     size: 'lg',
+    maxWidth: 500,
   },
 } as ComponentMeta<typeof SkeletonField>;
 

--- a/packages/vibrant-components/src/lib/Skeleton/SkeletonImage/SkeletonImage.stories.tsx
+++ b/packages/vibrant-components/src/lib/Skeleton/SkeletonImage/SkeletonImage.stories.tsx
@@ -6,6 +6,7 @@ export default {
   component: SkeletonImage,
   args: {
     width: 300,
+    maxWidth: 300,
     ratio: 1,
   },
 } as ComponentMeta<typeof SkeletonImage>;


### PR DESCRIPTION
Skeleton 스토리북에서 maxWidth가 control 패널에 보이지 않아서 디폴트로 값을 설정해서 보이게 합니다 ..

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/37496919/211785624-b2faa88e-97ef-411d-b9c3-52cf50f213e6.png">
