### PR TITLE
feat(utils-eslint-config): exclude JSON from naming convention

### DIFF
--- a/packages/utils-eslint-config/src/rules/typescript.js
+++ b/packages/utils-eslint-config/src/rules/typescript.js
@@ -76,7 +76,7 @@ const typescriptRules = {
       selector: ['default', 'variable', 'typeLike', 'typeProperty'],
       format: null,
       filter: {
-        regex: '(VStack|HStack|ZStack|CSS|Pretendard|HTML|ZIndex)',
+        regex: '(VStack|HStack|ZStack|CSS|Pretendard|HTML|ZIndex|JSON)',
         match: true,
       },
     },


### PR DESCRIPTION
toJSON 등을 mongoose에서 사용하게되는 경우가 있어 추가합니다.