### PR TITLE
fix: use native maxlength in TextInput

### DIFF
--- a/packages/vibrant-core/src/lib/TextInput/TextInput.tsx
+++ b/packages/vibrant-core/src/lib/TextInput/TextInput.tsx
@@ -18,7 +18,6 @@ export const TextInput = forwardRef<TextInputRef, TextInputProps>(
       type,
       defaultValue,
       pattern,
-      maxLength,
       hidden,
       focusStyle,
       autoCapitalize,
@@ -101,7 +100,7 @@ export const TextInput = forwardRef<TextInputRef, TextInputProps>(
           const replacedValue = replaceValue({
             pattern: type === 'number' ? /\d/ : pattern,
             value: event.currentTarget.value,
-          }).substring(0, maxLength);
+          });
 
           let isPrevented = false;
 


### PR DESCRIPTION
html에서 제공하는 maxLength attribute를 사용하여 maxLength 이상으로 입력되는 것을 막고, 커서가 맨 뒤로 이동하는 현상을 수정합니다.

### before

https://user-images.githubusercontent.com/37496919/215966521-567e46c3-a990-47c5-a693-dd1f05a9577d.mov

### after

https://user-images.githubusercontent.com/37496919/215966532-7978d6f6-0d0a-431b-acff-0777ffb076fe.mov

