### PR TITLE
fix: Portal scrollable할 때 컨텐츠가 줄어들지 않도록 한다

### DIFF
--- a/packages/vibrant-core/src/lib/Portal/Portal.native.tsx
+++ b/packages/vibrant-core/src/lib/Portal/Portal.native.tsx
@@ -52,7 +52,7 @@ export const Portal = withPortalVariation(({ innerRef, scrollable, children, sty
           ref={innerRef}
           {...restProps}
           style={{ ...style, position: 'absolute', top: 0, bottom: 0, left: 0, right: 0 }}
-          contentContainerStyle={{ flex: 1 }}
+          contentContainerStyle={{ flexGrow: 1 }}
         >
           {children}
         </ViewComponent>


### PR DESCRIPTION
iOS 앱 수강환경에서 vibrant ModalBottomSheet 내부 컨텐츠의 스크롤이 되지 않는 이슈 수정

Portal에서 ScrollView로 구현될 때 contentContainerStyle의 스타일 flex: 1로 인해 flexShirink: 0이 적용되어 컨텐츠가 원래 크기보다 줄어들 수 있었는데 flexGrow: 1만 주어 flexShirink 속성이 적용디지 않도록 합니다

### before
<img width="595" alt="image" src="https://user-images.githubusercontent.com/37496919/216248323-b47533ad-94ef-4e69-8fc2-f06eeda22745.png">


### after

https://user-images.githubusercontent.com/37496919/216248185-43b177eb-eff4-4fc7-a717-477b3c38382d.mov

