### PR TITLE
fix: 제어 모드로 SelectField를 사용하고 옵션이 달라지는 경우 무한 리렌더링 되는 이슈를 수정한다

### DIFF
--- a/packages/vibrant-components/src/lib/SelectField/SelectField.tsx
+++ b/packages/vibrant-components/src/lib/SelectField/SelectField.tsx
@@ -32,9 +32,9 @@ export const SelectField = withSelectFieldVariation(
     const [selectedOptionIndex, setSelectedOptionIndex] = useState<number>(
       defaultValue ? options.findIndex(option => !option.disabled && option.value === defaultValue) : -1
     );
+    const prevSelectedIndexRef = useRef<number | undefined>(selectedOptionIndex);
     const [focusIndex, setFocusIndex] = useState(-1);
     const [optionGroupMaxHeight, setOptionGroupMaxHeight] = useState<number | string>('auto');
-    const prevSelectedValueRef = useRef<string | undefined>(defaultValue);
     const handleValueChange = useCallbackRef(onValueChange);
 
     const ref = useRef<HTMLElement>(null);
@@ -97,24 +97,14 @@ export const SelectField = withSelectFieldVariation(
     );
 
     useEffect(() => {
-      if (!defaultValue) {
-        setSelectedOptionIndex(-1);
-
-        return;
-      }
-
-      setSelectedOptionIndex(options.findIndex(option => !option.disabled && option.value === defaultValue));
-    }, [defaultValue, options]);
-
-    useEffect(() => {
-      if (prevSelectedValueRef.current !== selectedOption?.value) {
+      if (prevSelectedIndexRef.current !== selectedOptionIndex) {
         setState('default');
 
-        handleValueChange?.(selectedOption?.value);
+        handleValueChange?.(options[selectedOptionIndex]?.value);
       }
 
-      prevSelectedValueRef.current = selectedOption?.value;
-    }, [handleValueChange, selectedOption?.value]);
+      prevSelectedIndexRef.current = selectedOptionIndex;
+    }, [handleValueChange, options, selectedOptionIndex]);
 
     useEffect(() => {
       setState(stateProp);


### PR DESCRIPTION
 selectedOption?.value는 업데이트 되기 전에 예전 값을 바라보고 있어서 selectedOptionIndex 상태로 선택된 값의 달라짐 여부를 판단하도록 합니다 ..

### before

https://user-images.githubusercontent.com/37496919/216573235-a914e044-06fb-4a50-a350-83e3c93fcd0c.mov


### after

https://user-images.githubusercontent.com/37496919/216573266-7bb03d07-8de8-4ecf-b07e-9eaf49e5b5a7.mov

