### PR TITLE
fix: defaultValue가 변경 되었을 때 selectedOptionIndex가 업데이트 되도록 수정한다

### DIFF
--- a/packages/vibrant-components/src/lib/SelectField/SelectField.tsx
+++ b/packages/vibrant-components/src/lib/SelectField/SelectField.tsx
@@ -97,6 +97,10 @@ export const SelectField = withSelectFieldVariation(
     );
 
     useEffect(() => {
+      setSelectedOptionIndex(options.findIndex(option => !option.disabled && option.value === defaultValue) ?? -1);
+    }, [defaultValue, options]);
+
+    useEffect(() => {
       if (prevSelectedIndexRef.current !== selectedOptionIndex) {
         setState('default');
 


### PR DESCRIPTION
defaultValue가 변경 되었을 때 selectedOptionIndex가 업데이트 되도록 수정했습니다.

### Before

https://user-images.githubusercontent.com/55270881/217134045-eda5dddc-c534-4b0e-a44f-4b2238955714.mov

### After

https://user-images.githubusercontent.com/55270881/217133668-1200458c-b010-445a-9ab6-4dc9029b8eb8.mov
