### PR TITLE
fix: calculate responsive value in ContentArea

### DIFF
--- a/packages/vibrant-components/src/lib/ContentArea/ContentArea.tsx
+++ b/packages/vibrant-components/src/lib/ContentArea/ContentArea.tsx
@@ -1,15 +1,19 @@
-import { useCurrentTheme } from '@vibrant-ui/core';
+import { calculateResponsiveValues, useCurrentTheme } from '@vibrant-ui/core';
 import { VStack } from '../VStack';
 import { withContentAreaVariation } from './ContentAreaProps';
 
-export const ContentArea = withContentAreaVariation(({ padding = true, children }) => {
+export const ContentArea = withContentAreaVariation(({ padding, children }) => {
   const {
     theme: { contentArea },
   } = useCurrentTheme();
 
+  const { px } = calculateResponsiveValues({ padding, px: contentArea.padding }, value => ({
+    px: value.padding ? value.px : 0,
+  }));
+
   return (
     <VStack alignHorizontal="center" width="100%">
-      <VStack maxWidth={contentArea.maxWidth} width="100%" px={padding ? contentArea.padding : 0}>
+      <VStack maxWidth={contentArea.maxWidth} width="100%" px={px}>
         {children}
       </VStack>
     </VStack>


### PR DESCRIPTION
기존에는 padding 을 responsiveValue 로 받아 따로 처리해주지 않고 그대로 내려주고 있었기 때문에 무조건 contentArea.padding 값이 넣어지고 있었습니다.
withVariation 에서 useCurrentTheme 을 사용하지 못해서 컴포넌트 내부 훅에서 calculate 해주는 방식으로 수정합니다


https://user-images.githubusercontent.com/105209178/218010874-ca3aa065-f72e-4e78-922a-a8baf93733d8.mov

