### PR TITLE
feat: allow 'auto' for Skeleton width, height value

### DIFF
--- a/packages/vibrant-components/src/lib/Skeleton/SkeletonProps.ts
+++ b/packages/vibrant-components/src/lib/Skeleton/SkeletonProps.ts
@@ -2,8 +2,8 @@ import type { BorderSystemProps, ReactElementChild, ResponsiveValue } from '@vib
 import { withVariation } from '@vibrant-ui/core';
 
 export type SkeletonProps = Pick<BorderSystemProps, 'borderRadiusLevel'> & {
-  width: ResponsiveValue<number | `${number}%`>;
-  height: ResponsiveValue<number | `${number}%`>;
+  width: ResponsiveValue<number | 'auto' | `${number}%`>;
+  height: ResponsiveValue<number | 'auto' | `${number}%`>;
   maxWidth?: ResponsiveValue<number | `${number}%`>;
   children?: ReactElementChild;
 };


### PR DESCRIPTION
### Before
<img width="316" alt="image" src="https://user-images.githubusercontent.com/33626219/220037925-d82baefb-51a0-4822-816a-30e1495a9d18.png">

### After
<img width="294" alt="image" src="https://user-images.githubusercontent.com/33626219/220037941-62ebc8ca-aaa0-41d7-90de-c044d5455027.png">
