### PR TITLE
fix: 네이티브에서 SafeAreaView의 width, height auto가 잘 작동하지 않는 문제를 해결한다

### DIFF
--- a/packages/vibrant-components/src/lib/SafeAreaView/SafeAreaView.stories.tsx
+++ b/packages/vibrant-components/src/lib/SafeAreaView/SafeAreaView.stories.tsx
@@ -24,3 +24,11 @@ export const Basic: ComponentStory<typeof SafeAreaView> = props => (
     <Box width={200} height={200} backgroundColor="primary" />
   </SafeAreaView>
 );
+
+export const withAutoHeight: ComponentStory<typeof SafeAreaView> = () => (
+  <Box width="100%" height={500}>
+    <SafeAreaView edges={['top']} backgroundColor="black" width="auto" height="auto">
+      <Box width={200} height={200} backgroundColor="primary" />
+    </SafeAreaView>
+  </Box>
+);

--- a/packages/vibrant-components/src/lib/SafeAreaView/SafeAreaView.tsx
+++ b/packages/vibrant-components/src/lib/SafeAreaView/SafeAreaView.tsx
@@ -30,7 +30,12 @@ export const SafeAreaView = withSafeAreaViewVariation(
 
     return (
       <Box width={width} height={height} {...(mode === 'margin' && style)}>
-        <Box width="100%" height="100%" {...(mode === 'padding' && style)} {...restProps}>
+        <Box
+          width={width === 'auto' ? 'auto' : '100%'}
+          height={height === 'auto' ? 'auto' : '100%'}
+          {...(mode === 'padding' && style)}
+          {...restProps}
+        >
           {children}
         </Box>
       </Box>


### PR DESCRIPTION
### Before
![image](https://user-images.githubusercontent.com/33626219/220290691-a09599af-f12b-4a6d-8eab-e7257d27f341.png)

### After
![image](https://user-images.githubusercontent.com/33626219/220290756-3b37009a-d47e-4288-9b40-488131407c3e.png)

