### PR TITLE
refactor: remove setting size 100% when min/maxSize defined

### DIFF
--- a/packages/vibrant-components/src/lib/Pressable/Pressable.tsx
+++ b/packages/vibrant-components/src/lib/Pressable/Pressable.tsx
@@ -17,11 +17,7 @@ export const Pressable = withPressableVariation(
     interactions,
     disabled = false,
     width,
-    minWidth,
-    maxWidth,
     height,
-    minHeight,
-    maxHeight,
     alignItems,
     justifyContent,
     p,
@@ -72,10 +68,6 @@ export const Pressable = withPressableVariation(
         }}
         onPressIn={() => setIsActivated(true)}
         onPressOut={() => setIsActivated(false)}
-        minWidth={minWidth}
-        maxWidth={maxWidth}
-        minHeight={minHeight}
-        maxHeight={maxHeight}
         {...(as === 'button' ? { as, buttonType } : { as })}
         {...restProps}
       >
@@ -96,8 +88,8 @@ export const Pressable = withPressableVariation(
         <Transition animation={{ opacity: textOpacity }} duration={200}>
           <Box
             as="span"
-            width={width ?? minWidth ?? maxWidth ? '100%' : 'auto'}
-            height={height ?? minHeight ?? maxHeight ? '100%' : 'auto'}
+            width={width ? '100%' : 'auto'}
+            height={height ? '100%' : 'auto'}
             alignItems={alignItems}
             justifyContent={justifyContent}
             p={p}


### PR DESCRIPTION
height/width가 명시적으로 정의되어 있지 않으면 사실상 100%는 의미 없는 것이 되어 버리기에 .. 불필요한 코드여서 삭제합니다