### PR TITLE
feat: add reverse property in Stack

### DIFF
--- a/packages/vibrant-components/src/lib/HStack/HStack.stories.tsx
+++ b/packages/vibrant-components/src/lib/HStack/HStack.stories.tsx
@@ -1,5 +1,6 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import { Box } from '@vibrant-ui/core';
+import { Body } from '../Body';
 import { HStack } from './HStack';
 
 export default {
@@ -12,10 +13,20 @@ export default {
 
 export const Basic: ComponentStory<typeof HStack> = props => (
   <HStack {...props} flex={1} width="100%" height="100%">
-    <Box width={100} minHeight={100} backgroundColor="primary" />
-    <Box width={100} minHeight={100} backgroundColor="primary" />
-    <Box width={200} minHeight={100} backgroundColor="primary" />
-    <Box width={100} minHeight={100} backgroundColor="primary" />
-    <Box width={100} minHeight={100} backgroundColor="primary" />
+    <Box width={100} minHeight={100} backgroundColor="primary" alignItems="center" justifyContent="center">
+      <Body level={3}>1</Body>
+    </Box>
+    <Box width={100} minHeight={100} backgroundColor="primary" alignItems="center" justifyContent="center">
+      <Body level={3}>2</Body>
+    </Box>
+    <Box width={200} minHeight={100} backgroundColor="primary" alignItems="center" justifyContent="center">
+      <Body level={3}>3</Body>
+    </Box>
+    <Box width={100} minHeight={100} backgroundColor="primary" alignItems="center" justifyContent="center">
+      <Body level={3}>4</Body>
+    </Box>
+    <Box width={100} minHeight={100} backgroundColor="primary" alignItems="center" justifyContent="center">
+      <Body level={3}>5</Body>
+    </Box>
   </HStack>
 );

--- a/packages/vibrant-components/src/lib/Stack/Stack.stories.tsx
+++ b/packages/vibrant-components/src/lib/Stack/Stack.stories.tsx
@@ -14,7 +14,7 @@ export default {
 export const Basic: ComponentStory<typeof Stack> = props => (
   <Stack {...props}>
     <Box width={200} height={200} backgroundColor="primary" borderRadius={12} />
-    <Box width={200} height={200} backgroundColor="primary" borderRadius={12} />
+    <Box width={200} height={200} backgroundColor="informative" borderRadius={12} />
   </Stack>
 );
 

--- a/packages/vibrant-components/src/lib/Stack/StackProps.ts
+++ b/packages/vibrant-components/src/lib/Stack/StackProps.ts
@@ -49,6 +49,7 @@ export type StackProps = DisplaySystemProps &
     alignVertical?: ResponsiveValue<Alignment>;
     ariaLabel?: string;
     scrollable?: boolean;
+    reverse?: ResponsiveValue<boolean>;
   } & Pick<BoxProps, 'onLayout'>;
 
 const CrossAlignmentMap: { [key in Alignment]: Exclude<AlignmentStyle, 'space-between'> } = {
@@ -75,17 +76,26 @@ export const withStackVariation = withVariation<StackProps>('Stack')(
         responsive: true,
         keep: true,
       },
+      {
+        name: 'reverse',
+        responsive: true,
+        default: false,
+        keep: true,
+      },
     ],
-    variants: {
-      horizontal: {
-        flexDirection: 'row',
-        horizontal: true,
-      },
-      vertical: {
-        flexDirection: 'column',
-        horizontal: false,
-      },
-    } as const,
+    variants: ({ direction, reverse }) => {
+      if (direction === 'horizontal') {
+        return {
+          flexDirection: reverse ? 'row-reverse' : 'row',
+          horizontal: true,
+        };
+      } else {
+        return {
+          flexDirection: reverse ? 'column-reverse' : 'column',
+          horizontal: false,
+        };
+      }
+    },
   }),
   propVariant({
     props: [

--- a/packages/vibrant-components/src/lib/VStack/VStack.stories.tsx
+++ b/packages/vibrant-components/src/lib/VStack/VStack.stories.tsx
@@ -1,5 +1,6 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import { Box } from '@vibrant-ui/core';
+import { Body } from '../Body';
 import { VStack } from './VStack';
 
 export default {
@@ -12,10 +13,20 @@ export default {
 
 export const Basic: ComponentStory<typeof VStack> = props => (
   <VStack {...props} flex={1} width="100%" height="100%">
-    <Box minWidth={100} height={100} backgroundColor="primary" />
-    <Box minWidth={100} height={100} backgroundColor="primary" />
-    <Box minWidth={200} height={100} backgroundColor="primary" />
-    <Box minWidth={100} height={100} backgroundColor="primary" />
-    <Box minWidth={100} height={100} backgroundColor="primary" />
+    <Box width={100} minHeight={100} backgroundColor="primary" alignItems="center" justifyContent="center">
+      <Body level={3}>1</Body>
+    </Box>
+    <Box width={100} minHeight={100} backgroundColor="primary" alignItems="center" justifyContent="center">
+      <Body level={3}>2</Body>
+    </Box>
+    <Box width={200} minHeight={100} backgroundColor="primary" alignItems="center" justifyContent="center">
+      <Body level={3}>3</Body>
+    </Box>
+    <Box width={100} minHeight={100} backgroundColor="primary" alignItems="center" justifyContent="center">
+      <Body level={3}>4</Body>
+    </Box>
+    <Box width={100} minHeight={100} backgroundColor="primary" alignItems="center" justifyContent="center">
+      <Body level={3}>5</Body>
+    </Box>
   </VStack>
 );


### PR DESCRIPTION
- Stack, VStack, HStack have a problemn with flexDirection property is overwritten by direction property. To fix this, add `reverse` boolean property to use `-reverse` direction.
- Update storybook content to show change apparently.

<img width="865" alt="스크린샷 2023-02-28 오전 10 55 47" src="https://user-images.githubusercontent.com/105209178/221733049-2a90e515-c888-4d0d-968a-cb59f5705de6.png">
