### PR TITLE
fix: prevent multiple onFilterChange call

### DIFF
--- a/packages/vibrant-components/src/lib/TableFilterGroup/TableDateFilter/TableDateFilter.tsx
+++ b/packages/vibrant-components/src/lib/TableFilterGroup/TableDateFilter/TableDateFilter.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { Box, useConfig, useCurrentTheme } from '@vibrant-ui/core';
-import { getDateString } from '@vibrant-ui/utils';
+import { getDateString, useCallbackRef } from '@vibrant-ui/utils';
 import type { DatePickerFieldRefValue } from '../../DatePickerField';
 import { DatePickerField } from '../../DatePickerField';
 import { RangePickerField } from '../../RangePickerField';
@@ -29,6 +29,7 @@ export const TableDateFilter = withTableDateFilterVariation(
       theme: { zIndex },
     } = useCurrentTheme();
     const { updateFilter } = useTableFilterGroup();
+    const handleFilterChange = useCallbackRef(updateFilter);
     const prevOperatorRef = useRef<DateFilterOperator | undefined>();
     const [fieldAutoFocus, setFieldAutoFocus] = useState(true);
     const fieldRef = useRef<DatePickerFieldRefValue | null>(null);
@@ -56,8 +57,8 @@ export const TableDateFilter = withTableDateFilterVariation(
     );
 
     useEffect(() => {
-      updateFilter();
-    }, [operator, value, updateFilter]);
+      handleFilterChange();
+    }, [operator, value, handleFilterChange]);
 
     useEffect(() => {
       if (!isDateFilterValid({ value, operator }) && prevOperatorRef.current !== operator) {

--- a/packages/vibrant-components/src/lib/TableFilterGroup/TableMultiSelectFilter/TableMultiSelectFilter.tsx
+++ b/packages/vibrant-components/src/lib/TableFilterGroup/TableMultiSelectFilter/TableMultiSelectFilter.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useImperativeHandle, useState } from 'react';
 import { Box, useConfig } from '@vibrant-ui/core';
+import { useCallbackRef } from '@vibrant-ui/utils';
 import { CheckboxGroupField } from '../../CheckboxGroupField';
 import { Divider } from '../../Divider';
 import { GhostButton } from '../../GhostButton';
@@ -27,6 +28,7 @@ export const TableMultiSelectFilter = withTableMultiSelectFilterVariation(
     const [selectedValues, setSelectedValues] = useState<Option['value'][]>(defaultValue?.value);
     const [operator, setOperator] = useState<MultiSelectFilterOperator>(defaultValue?.operator);
     const { updateFilter } = useTableFilterGroup();
+    const handleFilterChange = useCallbackRef(updateFilter);
 
     const {
       translations: {
@@ -57,8 +59,8 @@ export const TableMultiSelectFilter = withTableMultiSelectFilterVariation(
     );
 
     useEffect(() => {
-      updateFilter();
-    }, [selectedValues, operator, updateFilter]);
+      handleFilterChange();
+    }, [selectedValues, operator, handleFilterChange]);
 
     return (
       <TableFieldFilter

--- a/packages/vibrant-components/src/lib/TableFilterGroup/TableStringFilter/TableStringFilter.tsx
+++ b/packages/vibrant-components/src/lib/TableFilterGroup/TableStringFilter/TableStringFilter.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useImperativeHandle, useRef, useState } from 'react';
 import type { TextInputRef } from '@vibrant-ui/core';
 import { Box, useConfig } from '@vibrant-ui/core';
+import { useCallbackRef } from '@vibrant-ui/utils';
 import { TextField } from '../../TextField';
 import { useTableFilterGroup } from '../context';
 import { TableFieldFilter } from '../TableFieldFilter';
@@ -25,6 +26,7 @@ export const TableStringFilter = withTableStringFilterVariation(
     const [operator, setOperator] = useState<StringFilterOperator>(defaultValue?.operator);
     const [value, setValue] = useState<string>(inputValue);
     const { updateFilter } = useTableFilterGroup();
+    const handleFilterChange = useCallbackRef(updateFilter);
     const filedRef = useRef<TextInputRef | null>();
 
     const {
@@ -52,8 +54,8 @@ export const TableStringFilter = withTableStringFilterVariation(
     );
 
     useEffect(() => {
-      updateFilter();
-    }, [value, operator, updateFilter]);
+      handleFilterChange();
+    }, [value, operator, handleFilterChange]);
 
     useEffect(() => {
       filedRef.current?.focus();


### PR DESCRIPTION
updateFilter 함수의 레퍼런스가 달라져도 effect 함수가 호출되지 않도록 updateFilter를 useCallbackRef로 감싸서 같은 레퍼런스를 유지하도록 했습니다 

### before

https://user-images.githubusercontent.com/37496919/221767131-9d32d07b-e900-4e77-86ad-5dfca717c3c1.mov


### after

https://user-images.githubusercontent.com/37496919/221767139-762f456c-96e4-4d50-b3b8-fbbdb2ea4f36.mov

