### PR TITLE
fix(utils-eslint-config): add exception using _id in parameter

### DIFF
--- a/packages/utils-eslint-config/src/rules/typescript.js
+++ b/packages/utils-eslint-config/src/rules/typescript.js
@@ -111,7 +111,7 @@ const typescriptRules = {
 
     // _id와 __typename은 허용된다
     {
-      selector: ['typeProperty', 'objectLiteralProperty', 'classProperty'],
+      selector: ['parameter', 'typeProperty', 'objectLiteralProperty', 'classProperty'],
       format: null,
       filter: { regex: '^(_id|__typename)$', match: true },
     },


### PR DESCRIPTION
  static toEntity({ _id, ...data }: ArticleSchema): Article {
에서 _id 에러를 잡기 위해 parameter에 예외를 둡니다