### PR TITLE
fix: open Calendar when clicked in DatePickerField

### DIFF
--- a/packages/vibrant-components/src/lib/DateInput/DateInput.tsx
+++ b/packages/vibrant-components/src/lib/DateInput/DateInput.tsx
@@ -27,7 +27,6 @@ export const DateInput = withDateInputVariation(
     borderColor,
     helperText,
     autoFocus,
-    onClick,
     ...restProps
   }) => {
     const inputRef = useRef<any>(null);


### PR DESCRIPTION
Safari에서는 버튼 클릭시 포커스가 되지 않아서 .. https://github.com/pedaling/opensource/pull/558 의 변경사항으로 인해 Safari에서 캘린더가 열리지 않는 이슈가 있었습니다 .. Click했을 때 onFocus가 실행되도록 .. DateInput 구현을 수정합니다

### before

https://user-images.githubusercontent.com/37496919/224665215-47db5664-064d-4fe1-910b-5033ed1e117f.mov


### after
https://user-images.githubusercontent.com/37496919/224665014-79f0cd79-a949-42dd-9659-882869b19a1d.mov


https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#clicking_and_focus