### PR TITLE
fix: deleted grid link

### DIFF
--- a/packages/vibrant-website/docs/components/vibrant-core/box.mdx
+++ b/packages/vibrant-website/docs/components/vibrant-core/box.mdx
@@ -25,6 +25,7 @@ import { Box } from '@vibraBoxnt-ui/core';
 [DisplaySystemProps](/docs/system-props/display),
 [ElevationSystemProps](/docs/system-props/elevation),
 [FlexboxSystemProps](/docs/system-props/flexbox),
+GridSystemProps,
 [InputSystemProps](/docs/system-props/input),
 [InteractionSystemProps](/docs/system-props/interaction),
 [OverflowSystemProps](/docs/system-props/overflow),


### PR DESCRIPTION
- grid mdx 파일에 대한 링크가 부재해서 빌드가 에러나는 이슈를 수정합니다.

<img width="494" alt="스크린샷 2023-03-16 오후 2 22 05" src="https://user-images.githubusercontent.com/105209178/225522324-c2157c7c-83eb-4775-8add-a9c57840c26d.png">
