### PR TITLE
fix: themeProvider가 의미없는 리랜더링을 하지 않도록 한다

### DIFF
--- a/packages/vibrant-core/src/lib/ThemeProvider/ThemeProvider.tsx
+++ b/packages/vibrant-core/src/lib/ThemeProvider/ThemeProvider.tsx
@@ -58,7 +58,8 @@ export const ThemeProvider: FC<ThemeProviderProps> = ({ theme, root = false, chi
           dark: { ...parentTheme.opacity.dark, ...(theme.opacity?.dark ?? {}) },
         },
       } as Theme),
-    [parentTheme, theme]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(parentTheme), JSON.stringify(theme)]
   );
 
   const contextValue: ThemeContextValue = useMemo(


### PR DESCRIPTION
useMemo 디펜던시에 JSON.stringify한 theme 값들을 넣어서 ThemeProvider가 의미없는 리랜더링이 되지 않도록 했습니다