### PR TITLE
fix: don't pass as="a" when link dependency exists

### DIFF
--- a/packages/vibrant-core/src/lib/Link/Link.tsx
+++ b/packages/vibrant-core/src/lib/Link/Link.tsx
@@ -1,3 +1,4 @@
+import { isDefined } from '@vibrant-ui/utils';
 import { Box } from '../Box';
 import { useConfig } from '../ConfigProvider';
 import { withLinkVariation } from './LinkProps';
@@ -22,7 +23,7 @@ export const Link = withLinkVariation(
 
     return (
       <Box
-        as="a"
+        {...(isDefined(link) ? {} : { as: 'a' })}
         data-testid={testId}
         base={link}
         ref={innerRef}


### PR DESCRIPTION
next/link에서 as 속성이 .. vibrant에서 사용되는 것과는 다른 용도(Optional decorator for the path that will be shown in the browser URL bar.)로 사용되고 있어 클원 레포에 적용됐을 때 원치 않게 동작되는 이슈가 있어 link 컴포넌트가 따로 제공된 경우 as 속성을 넘기지 않도록 합니다.

참고: https://nextjs.org/docs/api-reference/next/link