### PR TITLE
feat: add card icon map to config provider dependency

### DIFF
--- a/packages/vibrant-components/src/lib/CustomizationProvider/CustomizationProvider.tsx
+++ b/packages/vibrant-components/src/lib/CustomizationProvider/CustomizationProvider.tsx
@@ -1,10 +1,13 @@
-import type { FC } from 'react';
+import type { ComponentType, FC } from 'react';
 import { createContext, useContext, useMemo } from 'react';
-import type { ReactElementChild } from '@vibrant-ui/core';
+import type { ReactElementChild, ResponsiveValue } from '@vibrant-ui/core';
 
 export type Configurations = {
   avatar?: {
     placeholder: string;
+  };
+  cardNumberField?: {
+    cardIconMap: Record<string, ComponentType<{ size: ResponsiveValue<number> }>>;
   };
 };
 
@@ -13,6 +16,9 @@ type CustomizationContextValue = Configurations;
 const CustomizationContext = createContext<CustomizationContextValue>({
   avatar: {
     placeholder: 'https://cdn.class101.net/images/e1cba897-73d1-43de-864b-c36cefdea670/200x200.png',
+  },
+  cardNumberField: {
+    cardIconMap: {},
   },
 });
 


### PR DESCRIPTION
slack: https://101inc.slack.com/archives/C03QFLRP39N/p1676007232491239?thread_ts=1675988853.335569&cid=C03QFLRP39N

class101 레포에서 vibrant CardNumberField에 쓰일 카드사 이미지를 주입받을 수 있도록 타입을 추가했습니다.