### PR TITLE
feat: filterchip에 maxWidth를 적용합니다

### DIFF
--- a/packages/vibrant-components/src/lib/FilterChip/FilterChip.stories.tsx
+++ b/packages/vibrant-components/src/lib/FilterChip/FilterChip.stories.tsx
@@ -1,5 +1,6 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import { Icon } from '@vibrant-ui/icons';
+import { HStack } from '../HStack';
 import { FilterChip } from './FilterChip';
 
 export default {
@@ -22,4 +23,16 @@ export const withHref: ComponentStory<typeof FilterChip> = props => (
 
 export const withLongText: ComponentStory<typeof FilterChip> = props => (
   <FilterChip {...props} children={'Long Text '.repeat(100)} />
+);
+
+export const withMultipleItem: ComponentStory<typeof FilterChip> = props => (
+  <HStack flexWrap="wrap" rowGap={8} overflow="hidden" width="100%">
+    <FilterChip {...props} children="Item 1" />
+    <FilterChip {...props} children="Item 2" />
+    <FilterChip {...props} children="Item 3" />
+    <FilterChip {...props} children="Item 4" />
+    <FilterChip {...props} children={'Item 5 '.repeat(5)} lineLimit={1} />
+    <FilterChip {...props} children={'Item 6 is long '.repeat(20)} lineLimit={2} />
+    <FilterChip {...props} children={'Item 7 is too long '.repeat(50)} lineLimit={3} />
+  </HStack>
 );

--- a/packages/vibrant-components/src/lib/FilterChip/FilterChip.tsx
+++ b/packages/vibrant-components/src/lib/FilterChip/FilterChip.tsx
@@ -6,8 +6,20 @@ import { Pressable } from '../Pressable';
 import { withFilterChipVariation } from './FilterChipProps';
 
 export const FilterChip = withFilterChipVariation(
-  ({ startIcon, endIcon, children, bodyLevel, color, spacing, iconSize, testId, lineLimit, ...props }) => (
-    <Pressable testId={testId} flexGrow={0} flexShrink={0} borderRadiusLevel={5} {...props}>
+  ({
+    startIcon,
+    endIcon,
+    children,
+    bodyLevel,
+    color,
+    spacing,
+    iconSize,
+    testId,
+    lineLimit,
+    maxWidth = '100%',
+    ...props
+  }) => (
+    <Pressable testId={testId} flexGrow={0} flexShrink={0} borderRadiusLevel={5} maxWidth={maxWidth} {...props}>
       <HStack as="span" my="auto" alignVertical="center">
         {startIcon && (
           <Box as="span" mr={spacing}>

--- a/packages/vibrant-components/src/lib/FilterChip/FilterChipProps.ts
+++ b/packages/vibrant-components/src/lib/FilterChip/FilterChipProps.ts
@@ -16,6 +16,7 @@ export type FilterChipProps = {
   testId?: string;
   href?: string;
   lineLimit?: ResponsiveValue<number>;
+  maxWidth?: ResponsiveValue<number | `${number}%`>;
 };
 
 export const withFilterChipVariation = withVariation<FilterChipProps>('FilterChip')(


### PR DESCRIPTION
| asis | tobe|
| ------ | ----- |
|  <img width="1247" alt="스크린샷 2023-04-04 오후 5 54 42" src="https://user-images.githubusercontent.com/100175974/229740926-72da9124-f445-41fe-ba4e-0559837e3c7c.png"> |  <img width="1249" alt="스크린샷 2023-04-04 오후 5 54 25" src="https://user-images.githubusercontent.com/100175974/229740912-76da3e15-8acf-496e-b50a-fcc120becaad.png">  |

- filterChip에 기본값 100%인 maxWidth를 적용해서 lineLimit이 정확하게 동작하도록 변경합니다.

<br/>

> ###### 코드

```js
  <HStack flexWrap="wrap" rowGap={8} overflow="hidden" width="100%">
    <FilterChip {...props} children="Item 1" />
    <FilterChip {...props} children="Item 2" />
    <FilterChip {...props} children="Item 3" />
    <FilterChip {...props} children="Item 4" />
    <FilterChip {...props} children={'Item 5 '.repeat(5)} lineLimit={1} />
    <FilterChip {...props} children={'Item 6 is long '.repeat(20)} lineLimit={2} />
    <FilterChip {...props} children={'Item 7 is too long '.repeat(50)} lineLimit={3} />
  </HStack>
```

