### PR TITLE
feat: change title level 1, 2 default tag  to h1

### DIFF
--- a/packages/vibrant-components/src/lib/Title/Title.tsx
+++ b/packages/vibrant-components/src/lib/Title/Title.tsx
@@ -3,8 +3,8 @@ import { Text } from '@vibrant-ui/core';
 import { withTitleVariation } from './TitleProps';
 
 const TitleLevelTagMap: { [level: number]: TextElements } = {
-  1: 'h2',
-  2: 'h2',
+  1: 'h1',
+  2: 'h1',
   3: 'h2',
   4: 'h3',
   5: 'h3',


### PR DESCRIPTION
<img width="858" alt="image" src="https://user-images.githubusercontent.com/37496919/231375644-2580510e-2bb5-43d0-911a-f62d304b828c.png">

Title이 level1, 2일 때 디폴트 태그를 h2 -> h1으로 수정합니다.
