### PR TITLE
fix: if heights.current[position][id] not exsits early return

### DIFF
--- a/packages/vibrant-core/src/lib/StackedPortalProvider/StackedPortalProvider.tsx
+++ b/packages/vibrant-core/src/lib/StackedPortalProvider/StackedPortalProvider.tsx
@@ -142,7 +142,7 @@ export const StackedPortalProvider: FC<StackedPortalProviderProps> = ({ children
 
   const changePortalHeight = useCallback<ChangePortalHeight>(
     ({ position, id, order, height }) => {
-      if (isDefined(heights.current[position][id]?.[order])) {
+      if (!isDefined(heights.current[position][id]?.[order])) {
         return;
       }
 


### PR DESCRIPTION
heights.current[position][id]가 존재하지 않을 때 order에 접근하지 않도록 방어 로직을 추가합니다