### PR TITLE
chore: filterChip 텍스트에 wordBreak 스타일 추가

### DIFF
--- a/packages/vibrant-components/src/lib/FilterChip/FilterChip.tsx
+++ b/packages/vibrant-components/src/lib/FilterChip/FilterChip.tsx
@@ -26,7 +26,7 @@ export const FilterChip = withFilterChipVariation(
             {cloneElement(startIcon, { size: iconSize, fill: color })}
           </Box>
         )}
-        <Body level={bodyLevel} color={color} lineLimit={lineLimit}>
+        <Body level={bodyLevel} color={color} lineLimit={lineLimit} wordBreak={lineLimit ? 'break-all' : 'normal'}>
           {children}
         </Body>
         {endIcon && (


### PR DESCRIPTION
### asis

<img width="365" alt="스크린샷 2023-04-14 오후 1 58 10" src="https://user-images.githubusercontent.com/100175974/231945643-65ca1ff5-6049-4e0c-966f-62774e931d99.png">

`카카오톡 ...`

### tobe

<img width="361" alt="image" src="https://user-images.githubusercontent.com/100175974/231945777-eeb6bcb4-019a-4ac5-bb65-03d54222174a.png">

`카카오톡 이모...`

- filterChip의 텍스트에 wordBreak 스타일을 추가해서 단어 단위가 아닌 음절 단위로 말줄임 처리가 되도록 합니다
