### PR TITLE
feat: set build setting of vibrant-motion to let .native extenstion

### DIFF
--- a/packages/vibrant-motion/project.json
+++ b/packages/vibrant-motion/project.json
@@ -7,10 +7,18 @@
     "build": {
       "executor": "@nrwl/rollup:rollup",
       "outputs": ["{options.outputPath}"],
+      "dependsOn": [
+        {
+          "target": "build",
+          "projects": "dependencies"
+        },
+        "build-native"
+      ],
       "options": {
         "outputPath": "dist/packages/vibrant-motion",
         "tsConfig": "packages/vibrant-motion/tsconfig.lib.json",
         "project": "packages/vibrant-motion/package.json",
+        "deleteOutputPath": false,
         "entryFile": "packages/vibrant-motion/src/index.ts",
         "external": ["react/jsx-runtime"],
         "generateExportsField": true,
@@ -25,6 +33,25 @@
             "output": "."
           }
         ]
+      }
+    },
+    "build-native": {
+      "executor": "@nrwl/rollup:rollup",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/vibrant-motion",
+        "tsConfig": "packages/vibrant-motion/tsconfig.lib.json",
+        "moduleSuffixes": [".native", ""],
+        "project": "packages/vibrant-motion/package.json",
+        "outputFileName": "index.native",
+        "entryFile": "packages/vibrant-motion/src/index.ts",
+        "external": ["react/jsx-runtime"],
+        "forceOutputJsExtension": true,
+        "format": ["cjs"],
+        "rollupConfig": "tools/config/rollup-config",
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "compiler": "babel",
+        "disablePreserveModules": true
       }
     },
     "typecheck": {


### PR DESCRIPTION
### before
<img width="172" alt="image" src="https://user-images.githubusercontent.com/37496919/233885552-5932ba7c-8be1-4d64-b290-d21e18b5d6f3.png">


### after
<img width="170" alt="image" src="https://user-images.githubusercontent.com/37496919/233884763-195aaebb-061d-4aaf-8367-5157c7c0f87f.png">

vibrant-core처럼 native 파일을 분기하여 구현을 따로 할 수 있도록 빌드 설정을 수정합니다 
