### PR TITLE
fix: motion 에서 exports 시에 native 를 바라보게 generateExportsField options 을 끈다

### DIFF
--- a/packages/vibrant-motion/project.json
+++ b/packages/vibrant-motion/project.json
@@ -21,7 +21,6 @@
         "deleteOutputPath": false,
         "entryFile": "packages/vibrant-motion/src/index.ts",
         "external": ["react/jsx-runtime"],
-        "generateExportsField": true,
         "format": ["esm", "cjs"],
         "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
         "buildableProjectDepsInPackageJsonType": "dependencies",


### PR DESCRIPTION
현재 project.json

<img width="501" alt="스크린샷 2023-05-06 오후 5 49 06" src="https://user-images.githubusercontent.com/52653675/236613857-c626ba32-845c-46f1-a8a9-082028912a1b.png">



<img width="497" alt="스크린샷 2023-05-06 오후 5 50 32" src="https://user-images.githubusercontent.com/52653675/236613913-59e0fe35-a831-47df-85d3-e838327a83dc.png">

