### PR TITLE
fix: StackedPortal 애니메이션 시 hidden일 때 초기에 잠깐 노출되는 버그를 수정한다

### DIFF
--- a/packages/vibrant-components/src/lib/StackedPortal/StackedPortal.tsx
+++ b/packages/vibrant-components/src/lib/StackedPortal/StackedPortal.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { LayoutEvent } from '@vibrant-ui/core';
-import { PortalBox, useResponsiveValue, useSafeArea, useStackedPortal } from '@vibrant-ui/core';
+import { PortalBox, useResponsiveValue, useSafeArea, useStackedPortal, useWindowDimensions } from '@vibrant-ui/core';
 import { Transition } from '@vibrant-ui/motion';
 import { addStyleValues, isDefined } from '@vibrant-ui/utils';
 import { withStackedPortalVariation } from './StackedPortalProps';
@@ -21,6 +21,7 @@ export const StackedPortal = withStackedPortalVariation(
     ...restProps
   }) => {
     const { generateStyle } = useSafeArea();
+    const { height: viewportHeight } = useWindowDimensions();
 
     const { getResponsiveValue } = useResponsiveValue();
 
@@ -88,8 +89,9 @@ export const StackedPortal = withStackedPortalVariation(
     return duration ? (
       <Transition
         animation={{
-          [currentPosition]: addStyleValues(offset ?? 0, hidden ? -height : 0),
+          ...(height !== 0 ? { [currentPosition]: addStyleValues(offset ?? 0, hidden ? -height : 0) } : {}),
         }}
+        style={{ [currentPosition]: hidden ? -viewportHeight : 0 }}
         duration={duration}
       >
         <PortalBox ref={innerRef} hidden={!isDefined(offset)} onLayout={handleLayout} {...restProps}>


### PR DESCRIPTION
초기 위치를 viewportHeight만큼 설정해서 보이지 않게 합니다.

### before

https://github.com/pedaling/opensource/assets/37496919/79aabad0-1e5d-4ff6-85af-92c6460ce843


### after

https://github.com/pedaling/opensource/assets/37496919/6c4c9cfc-3708-40bd-af88-28e8c776aff9

