### PR TITLE
fix: set TableSearchOption storybook option args

### DIFF
--- a/packages/vibrant-components/src/lib/TableSearch/TableSearchOption/TableSearchOption.stories.tsx
+++ b/packages/vibrant-components/src/lib/TableSearch/TableSearchOption/TableSearchOption.stories.tsx
@@ -4,7 +4,15 @@ import { TableSearchOption } from './TableSearchOption';
 export default {
   title: 'TableSearchOption',
   component: TableSearchOption,
-  args: {},
+  args: {
+    options: [
+      { label: 'id', value: 'id' },
+      { label: 'title', value: 'title' },
+      { label: 'content', value: 'content' },
+      { label: 'author', value: 'author' },
+      { label: 'createdAt', value: 'createdAt' },
+    ],
+  },
 } as ComponentMeta<typeof TableSearchOption>;
 
 export const Basic: ComponentStory<typeof TableSearchOption> = props => <TableSearchOption {...props} />;


### PR DESCRIPTION
- As is
<img width="832" alt="스크린샷 2023-05-18 22 23 57" src="https://github.com/pedaling/opensource/assets/100661305/716ec200-bbb9-46ad-bbdf-2aa0dc42dc29">

- To be
<img width="832" alt="스크린샷 2023-05-18 22 24 30" src="https://github.com/pedaling/opensource/assets/100661305/5c6705cd-8b7f-4f12-8c9c-34916e04c9e0">
