### PR TITLE
feat: customization context's card icon map size prop to optional

### DIFF
--- a/packages/vibrant-components/src/lib/CustomizationProvider/CustomizationProvider.tsx
+++ b/packages/vibrant-components/src/lib/CustomizationProvider/CustomizationProvider.tsx
@@ -7,7 +7,7 @@ export type Configurations = {
     placeholder: string;
   };
   cardNumberField?: {
-    cardIconMap: Record<string, ComponentType<{ size: ResponsiveValue<number> }>>;
+    cardIconMap: Record<string, ComponentType<{ size?: ResponsiveValue<number> }>>;
   };
 };
 


### PR DESCRIPTION
size가 CardNumberField에서 고정인데 이를 반드시 주입하도록 하여 class101 repository에서 사용시 타입에러가 났습니다.
=> CardNumberField 주입해줄 cardIconMap에 size를 optional하게 수정했습니다.