### PR TITLE
fix: remove horizontal padding when desktop viewport in VierwPagerTab

### DIFF
--- a/packages/vibrant-components/src/lib/ViewPagerTabGroup/ViewPagerTabGroup.tsx
+++ b/packages/vibrant-components/src/lib/ViewPagerTabGroup/ViewPagerTabGroup.tsx
@@ -14,7 +14,7 @@ export const ViewPagerTabGroup = withViewPagerTabGroupVariation(({ children, tes
   <TabView
     testId={testId}
     renderTobBarContainer={props => (
-      <HStack px={20} spacing={tabSpacing} data-testid="top-bar-container">
+      <HStack px={[20, 20, 0]} spacing={tabSpacing} data-testid="top-bar-container">
         {props}
       </HStack>
     )}


### PR DESCRIPTION
데스크탑 이상 뷰포트에서 좌우 패딩 제거

### Before
<img width="247" alt="image" src="https://github.com/pedaling/opensource/assets/37496919/458c45f6-29fe-4489-bbb0-41ea559c27b7">


### After 
<img width="386" alt="image" src="https://github.com/pedaling/opensource/assets/37496919/0d5df43a-bbc2-42c6-9831-bf90ca71555f">
