### PR TITLE
perf: use string instead of regex in get function

### DIFF
--- a/packages/vibrant-utils/src/lib/get/get.ts
+++ b/packages/vibrant-utils/src/lib/get/get.ts
@@ -1,10 +1,8 @@
 export const get = (obj: Record<string, any>, path: string, defaultValue?: any): any => {
-  const travel = (regexp: RegExp) =>
-    String.prototype.split
-      .call(path, regexp)
-      .filter(Boolean)
-      .reduce((res, key) => (res !== null && res !== undefined ? res[key] : res), obj);
-  const result = travel(/[,[\]]+?/) || travel(/[,[\].]+?/);
+  const result = path
+    .split('.')
+    .filter(Boolean)
+    .reduce((res, key) => (res !== null && res !== undefined ? res[key] : res), obj);
 
   return result === undefined || result === obj ? defaultValue : result;
 };


### PR DESCRIPTION
theme에서 `${scale}.${value}`과 같은 형식으로 값을 가져오 때 사용하는 get 함수에서 regex를 사용하지 않고 string으로 split하도록 수정합니다. 

- vibrant-benchmark-app 기준 App 평균 렌더링 시간: 26.8 -> 23.6ms 단축
- 참고: https://www.measurethat.net/Benchmarks/Show/4781/0/split-vs-regex