### PR TITLE
fix: drawer 컴포넌트 QA 반영

### DIFF
--- a/packages/vibrant-components/src/lib/Drawer/DrawerPanel/DrawerPanel.tsx
+++ b/packages/vibrant-components/src/lib/Drawer/DrawerPanel/DrawerPanel.tsx
@@ -75,7 +75,7 @@ export const DrawerPanel = withDrawerPanelVariation(({ testId = 'drawer-panel', 
   return isStandardType ? (
     <>
       {placement === 'right' && (
-        <Box position="absolute" top={0} right={0} height="100%">
+        <Box position="absolute" top={0} right={0} height="100%" flexDirection="row">
           <Box flex={0}>
             <Divider direction="vertical" kind="default" />
           </Box>
@@ -93,7 +93,7 @@ export const DrawerPanel = withDrawerPanelVariation(({ testId = 'drawer-panel', 
         </Box>
       )}
       {placement === 'left' && (
-        <Box position="absolute" top={0} left={0} height="100%">
+        <Box position="absolute" top={0} left={0} height="100%" flexDirection="row">
           <Transition
             animation={{
               x: isOpen ? panelSizePixel : 0,
@@ -156,7 +156,7 @@ export const DrawerPanel = withDrawerPanelVariation(({ testId = 'drawer-panel', 
             top={0}
             right={-panelSizePixel}
             zIndex={3}
-            elevationLevel={3}
+            elevationLevel={isOpen ? 3 : undefined}
           >
             {panelContent}
           </Box>
@@ -171,7 +171,7 @@ export const DrawerPanel = withDrawerPanelVariation(({ testId = 'drawer-panel', 
             top={0}
             left={-panelSizePixel}
             zIndex={3}
-            elevationLevel={3}
+            elevationLevel={isOpen ? 3 : undefined}
           >
             {panelContent}
           </Box>
@@ -186,7 +186,7 @@ export const DrawerPanel = withDrawerPanelVariation(({ testId = 'drawer-panel', 
             top={-panelSizePixel}
             left={0}
             zIndex={3}
-            elevationLevel={3}
+            elevationLevel={isOpen ? 3 : undefined}
           >
             {panelContent}
           </Box>
@@ -201,7 +201,7 @@ export const DrawerPanel = withDrawerPanelVariation(({ testId = 'drawer-panel', 
             bottom={-panelSizePixel}
             left={0}
             zIndex={3}
-            elevationLevel={3}
+            elevationLevel={isOpen ? 3 : undefined}
           >
             {panelContent}
           </Box>


### PR DESCRIPTION
#### type=standard일 때 DrawerPanel에 divider가 존재하지 않는다
- As is 
<img width="149" alt="Screenshot 2023-05-26 at 21 12 57" src="https://github.com/pedaling/opensource/assets/100661305/b34a10a2-b34f-47d6-92f6-3eb8bec8d7fb">

- To be
<img width="310" alt="스크린샷 2023-06-05 16 15 43" src="https://github.com/pedaling/opensource/assets/100661305/167b0873-35ec-4850-b5b0-964417d8fc6b">


#### type=overlay, type=modal일 때 닫혀 있어도 DrawerPanel의 그림자가 노출된다
- As is
<img width="291" alt="Screenshot 2023-05-26 at 21 24 04" src="https://github.com/pedaling/opensource/assets/100661305/6320550d-41e8-4541-ba48-35fe8dde5bd1">

- To be
<img width="310" alt="스크린샷 2023-06-05 16 14 42" src="https://github.com/pedaling/opensource/assets/100661305/000f5bd8-e5a4-4420-9a6b-9cbf1dd4ec72">
