### PR TITLE
chore: @storybook/native-addon 패키지를 설치한다

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@storybook/addon-viewport": "7.0.12",
     "@storybook/core-server": "7.0.12",
     "@storybook/native": "2.2.8",
+    "@storybook/native-addon": "2.2.8",
     "@storybook/native-dev-middleware": "2.2.8",
     "@storybook/react": "7.0.12",
     "@storybook/react-vite": "7.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8485,7 +8485,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/native-addon@npm:^2.2.8":
+"@storybook/native-addon@npm:2.2.8, @storybook/native-addon@npm:^2.2.8":
   version: 2.2.8
   resolution: "@storybook/native-addon@npm:2.2.8"
   dependencies:
@@ -14123,6 +14123,7 @@ __metadata:
     "@storybook/addon-viewport": 7.0.12
     "@storybook/core-server": 7.0.12
     "@storybook/native": 2.2.8
+    "@storybook/native-addon": 2.2.8
     "@storybook/native-components": 2.2.8
     "@storybook/native-dev-middleware": 2.2.8
     "@storybook/react": 7.0.12


### PR DESCRIPTION
@storybook/native-addon 쪽에서 에러가 나면서 스토리북 빌드가 실패하고 있는데 해당 패키지가 사용되는데 설치되어 있지 않아 발생하고 있지 않을까 하는 추측으로 ..