### PR TITLE
refactor: change returned component of createNativeImageComponent obectFit prop type

### DIFF
--- a/packages/vibrant-core/src/lib/createNativeImageComponent/createNativeImageComponent.tsx
+++ b/packages/vibrant-core/src/lib/createNativeImageComponent/createNativeImageComponent.tsx
@@ -1,6 +1,9 @@
 import type { ComponentType } from 'react';
 import { forwardRef } from 'react';
 import type { ImageRequireSource } from 'react-native';
+import { Box } from '../Box';
+import type { MediaSystemProps } from '../props';
+import { useResponsiveValue } from '../useResponsiveValue';
 
 type ImageComponentType = ComponentType<{
   source?: ImageRequireSource | { uri?: string };
@@ -10,8 +13,7 @@ type ImageComponentType = ComponentType<{
 type ImageProps = {
   ref?: any;
   src: ImageRequireSource | string;
-  objectFit?: 'contain' | 'cover' | 'fill' | 'none';
-};
+} & MediaSystemProps;
 
 const ObjectFitResizeModeMap = {
   contain: 'contain',
@@ -21,11 +23,17 @@ const ObjectFitResizeModeMap = {
 } as const;
 
 export const createNativeImageComponent = (ImageComponent: ImageComponentType) =>
-  forwardRef<any, ImageProps>(({ src, objectFit, ...restProps }, ref) => (
-    <ImageComponent
-      ref={ref}
-      source={typeof src === 'string' ? { uri: src } : src}
-      resizeMode={objectFit ? ObjectFitResizeModeMap[objectFit] : undefined}
-      {...restProps}
-    />
-  ));
+  forwardRef<any, ImageProps>(({ src, objectFit, ...restProps }, ref) => {
+    // TODO: react-native 0.71로 버전 업 시 objectFit을 resizeMode로 변환하지 않습니다
+    const { getResponsiveValue } = useResponsiveValue();
+
+    return (
+      <Box
+        base={ImageComponent}
+        ref={ref}
+        source={typeof src === 'string' ? { uri: src } : src}
+        resizeMode={objectFit ? ObjectFitResizeModeMap[getResponsiveValue(objectFit)] : undefined}
+        {...restProps}
+      />
+    );
+  });


### PR DESCRIPTION
 [ConfigProvider의 ImageComponent 속성 타입을 responsive로 받게 수정](https://github.com/pedaling/opensource/pull/693)되어 createNativeImageComponent 함수 리턴 타입을 수정했습니다. react-native 0.71버전에서는 objectFit 속성이 지원되어 resizeMode로 변환하기 위한 과정이 필요없어지기 때문에 별도 PR로 작업하고자 comment를 남겼습니다.