### PR TITLE
fix: react-native-reanimated를 peerDependency에 둔다

### DIFF
--- a/packages/vibrant-motion/package.json
+++ b/packages/vibrant-motion/package.json
@@ -8,6 +8,7 @@
     "@types/react": "^17.0.0 || ^18.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-spring": "^9.0.0",
+    "react-native": "^0.63.0",
     "react-native-reanimated": "~2.14.4"
   },
   "dependencies": {},


### PR DESCRIPTION
- react-native-reanimated가 두개 이상 설치될 일이 없도록 peerDependency에 위치시켰습니다