### PR TITLE
fix: @vibrant/motion 라이브러리가 exports 필드를 생성하지 않도록 한다

### DIFF
--- a/packages/vibrant-core/package.json
+++ b/packages/vibrant-core/package.json
@@ -15,7 +15,8 @@
     "@emotion/is-prop-valid": "^1.1.3",
     "@emotion/memoize": "^0.7.4",
     "@emotion/native": "^11.5.0",
-    "react-native-safe-area-context": "^3.3.2 || ^4.3.1"
+    "react-native-safe-area-context": "^3.3.2 || ^4.3.1",
+    "react-native-gesture-handler": "^2.5.0"
   },
   "devDependencies": {
     "@emotion/native": "^11.5.0"

--- a/packages/vibrant-motion/project.json
+++ b/packages/vibrant-motion/project.json
@@ -22,7 +22,6 @@
         "deleteOutputPath": false,
         "entryFile": "packages/vibrant-motion/src/index.ts",
         "external": ["react/jsx-runtime"],
-        "generateExportsField": true,
         "format": ["esm", "cjs"],
         "rollupConfig": "@nx/react/plugins/bundle-rollup",
         "buildableProjectDepsInPackageJsonType": "dependencies",


### PR DESCRIPTION
- 네이티브 분기가 들어가는 라이브러리는 exports 필드가 존재하면 react-native 필드를 덮어씌워버려서 생성하지 않도록 했습니다
- core 디펜던시에 있는 react-native-gesture-handler가 버전이 고정되어있는 문제를 수정했습니다