### PR TITLE
fix: 안드로이드/ 태블릿 뷰에서 모달이 위쪽으로 align되는 이슈를 수정한다

### DIFF
--- a/packages/vibrant-core/src/lib/Portal/Portal.native.tsx
+++ b/packages/vibrant-core/src/lib/Portal/Portal.native.tsx
@@ -49,7 +49,12 @@ export const Portal = withPortalVariation(({ innerRef, scrollable, children, sty
     return (
       <FullWindowOverlay>
         <View pointerEvents="box-none" style={{ position: 'absolute', width, height, top, bottom, left, right }}>
-          <ViewComponent ref={innerRef} {...restProps} style={style} contentContainerStyle={{ flexGrow: 1 }}>
+          <ViewComponent
+            ref={innerRef}
+            {...restProps}
+            style={style}
+            {...(scrollable ? { contentContainerStyle: { flexGrow: 1 } } : {})}
+          >
             {children}
           </ViewComponent>
         </View>
@@ -62,7 +67,7 @@ export const Portal = withPortalVariation(({ innerRef, scrollable, children, sty
       ref={innerRef}
       {...restProps}
       style={{ ...style, position: 'absolute' }}
-      contentContainerStyle={{ flexGrow: 1 }}
+      {...(scrollable ? { contentContainerStyle: { flexGrow: 1 } } : {})}
     >
       {children}
     </ViewComponent>,


### PR DESCRIPTION
Portal이 스크롤가능할 때 ScrollView로 렌더링 되는데 안드로이드에서는 contentContainerStyle={{ flexGrow:1 }}을 안주고 있어서 컨텐츠가 늘어나지 않는 것이 원인이었습니다 ...