### PR TITLE
fix: textinput textAlignVertical top on android

### DIFF
--- a/packages/vibrant-core/src/lib/TextInput/TextInput.native.tsx
+++ b/packages/vibrant-core/src/lib/TextInput/TextInput.native.tsx
@@ -47,6 +47,7 @@ export const TextInput = forwardRef<TextInputRef, TextInputProps>(
       onKeyPress,
       onValueChange,
       onSubmit,
+      textAlignVertical = 'top',
       ...restProps
     },
     ref
@@ -98,6 +99,7 @@ export const TextInput = forwardRef<TextInputRef, TextInputProps>(
         value={value}
         editable={!readOnly && !disabled}
         secureTextEntry={type === 'password'}
+        textAlignVertical={textAlignVertical}
         onFocus={() => {
           setIsFocused(true);
 

--- a/packages/vibrant-core/src/lib/TextInput/TextInputProps.ts
+++ b/packages/vibrant-core/src/lib/TextInput/TextInputProps.ts
@@ -196,6 +196,11 @@ export type TextInputProps = SystemProps &
       target?: HTMLInputElement | null;
     }) => void;
     onSubmit?: (value: string) => void;
+    /**
+     * Vertically align text when `multiline` is set to true.
+     * on Android only.
+     */
+    textAlignVertical?: 'auto' | 'bottom' | 'center' | 'top';
   };
 
 export const interpolation = injectContext(


### PR DESCRIPTION
iOS 에서는 top 에 align 맞춰져 있는데, android 도 같은 디자인을 맞추기 위해서 기본값을 top 으로 넣어주게 되어있습니다 .!

value 없을때 placeholder 가운데 정렬 하게될수도 있어서, props 으로 받게하였습니다