### PR TITLE
fix: portal native to fix stackedPortal and toast

### DIFF
--- a/packages/vibrant-components/src/lib/Toast/Toast.tsx
+++ b/packages/vibrant-components/src/lib/Toast/Toast.tsx
@@ -9,13 +9,7 @@ import { withToastVariation } from './ToastProps';
 export const Toast = withToastVariation(
   ({ innerRef, IconComponent, color, title, buttonText, onButtonClick, testId = 'toast', ...restProps }) => (
     <HStack ref={innerRef} {...restProps} px={20} width="100%" alignHorizontal="center" data-testid={testId}>
-      <Paper
-        borderRadiusLevel={1}
-        backgroundColor="inverseSurface"
-        elevationLevel={1}
-        maxWidth={816}
-        width={['100%', 'auto']}
-      >
+      <Paper borderRadiusLevel={1} backgroundColor="inverseSurface" maxWidth={816} width={['100%', 'auto']}>
         <HStack px={16} py={12} alignVertical="center" width={['100%', 'auto']}>
           {IconComponent && (
             <VStack mr={8} flexShrink={0}>

--- a/packages/vibrant-core/src/lib/Portal/Portal.native.tsx
+++ b/packages/vibrant-core/src/lib/Portal/Portal.native.tsx
@@ -15,8 +15,6 @@ export const Portal = withPortalVariation(({ innerRef, scrollable, children, sty
 
   const [container, setContainer] = useState<Element | number | null>(null);
 
-  const { top, right, bottom, left } = style;
-
   useEffect(() => {
     let containerIndex: number | null = null;
 
@@ -48,11 +46,11 @@ export const Portal = withPortalVariation(({ innerRef, scrollable, children, sty
   if (platform === 'ios') {
     return (
       <FullWindowOverlay>
-        <View pointerEvents="box-none" style={{ position: 'absolute', width, height, top, bottom, left, right }}>
+        <View pointerEvents="box-none" style={{ position: 'absolute', width, height, top: 0, left: 0, right: 0 }}>
           <ViewComponent
             ref={innerRef}
             {...restProps}
-            style={style}
+            style={{ ...style, position: 'absolute' }}
             {...(scrollable ? { contentContainerStyle: { flexGrow: 1 } } : {})}
           >
             {children}


### PR DESCRIPTION
- 기존 코드에서 style 에 넣어진 top 값이 한번 적용되고, ViewComponent 에서도 top 값이 적용되며 offset 이 두번 적용되어서 토스트나 StackedPortal 이 정상 작동하지 않던 이슈를 해결합니다.
- Bottom 0 은 안넣어줘도 되는건가요?
  height, width 가 100 으로 window 만큼 찬 상태에서 top :0 이 먹혀있기 때문에 상위 View 는 세팅되고, 그 하위에 있는 실질적으로 띄워지는 portal view (ViewComponent) 가 bottom 또는 top 이 설정한 styles값만큼 적용되기 때문에 상관없음! 
![Simulator Screen Shot - iPhone 14 Pro - 2023-07-11 at 11 11 32](https://github.com/pedaling/opensource/assets/105209178/68e82d8d-1ea6-4c87-8e6c-7824ca72e79a)
![Simulator Screen Shot - iPhone 14 Pro - 2023-07-11 at 11 11 28](https://github.com/pedaling/opensource/assets/105209178/19c2ab49-1d06-4904-987d-b189b932ca72)

https://github.com/pedaling/opensource/assets/105209178/2a9c7458-905c-42d1-bc73-52fcdffd9c61

