### PR TITLE
feat: "ModalBottonSheet"가 primary+secondary 인 경우 버튼 정렬을 vertical 로 변경

### DIFF
--- a/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.tsx
+++ b/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.tsx
@@ -195,18 +195,7 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
                   </VStack>
                 )}
                 {isDefined(primaryButtonOptions) && isDefined(secondaryButtonOptions) && !isDefined(subButtonOptions) && (
-                  <HStack px={[20, 32]} mt={[20, 24]} flexShrink={0} width="100%" spacing={[8, 16]}>
-                    <ContainedButton
-                      kind={secondaryButtonOptions.kind ?? 'tertiary'}
-                      size="xl"
-                      onClick={() => secondaryButtonOptions.onClick?.({ close: closeModal })}
-                      full={true}
-                      disabled={secondaryButtonOptions.disabled}
-                      loading={secondaryButtonOptions.loading}
-                      IconComponent={secondaryButtonOptions.IconComponent}
-                    >
-                      {secondaryButtonOptions.text}
-                    </ContainedButton>
+                  <VStack px={[20, 32]} mt={[20, 24]} flexShrink={0} width="100%" spacing={8}>
                     <ContainedButton
                       kind={primaryButtonOptions.kind ?? 'primary'}
                       size="xl"
@@ -218,7 +207,18 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
                     >
                       {primaryButtonOptions.text}
                     </ContainedButton>
-                  </HStack>
+                    <ContainedButton
+                      kind={secondaryButtonOptions.kind ?? 'tertiary'}
+                      size="xl"
+                      onClick={() => secondaryButtonOptions.onClick?.({ close: closeModal })}
+                      full={true}
+                      disabled={secondaryButtonOptions.disabled}
+                      loading={secondaryButtonOptions.loading}
+                      IconComponent={secondaryButtonOptions.IconComponent}
+                    >
+                      {secondaryButtonOptions.text}
+                    </ContainedButton>
+                  </VStack>
                 )}
                 {isDefined(primaryButtonOptions) && !isDefined(secondaryButtonOptions) && isDefined(subButtonOptions) && (
                   <VStack px={[20, 32]} mt={[20, 24]} flexShrink={0} width="100%" spacing={16}>


### PR DESCRIPTION
변경 사항
* ModalBottomSheet 가 Primary + Secondary 버튼을 가지는 형태일 경우 가로 정렬이 아닌 세로 정렬이 되도록 수정
* JIRA : https://101inc.atlassian.net/browse/PI-6361
* [관련 Figma 논의 내용](https://www.figma.com/file/xxoL2T3TZ6YyjqLIAswGU6?node-id=2665:191042&mode=design#500571761)

before

<img width="603" alt="image" src="https://github.com/pedaling/opensource/assets/122358526/caac3164-31eb-4fd1-a85f-60b2fb391501">

after

<img width="611" alt="image" src="https://github.com/pedaling/opensource/assets/122358526/308cefc3-abcc-4edb-bfbd-22bcb5316613">


