### PR TITLE
fix: 스위치가 보이지 않는 이슈를 해결한다.

### DIFF
--- a/packages/vibrant-components/src/lib/Switch/Switch.tsx
+++ b/packages/vibrant-components/src/lib/Switch/Switch.tsx
@@ -14,6 +14,7 @@ export const Switch = withSwitchVariation(
     height,
     disabled,
     width,
+    id,
     testId = 'switch',
   }) => {
     const [isChecked, setIsChecked] = useState(defaultValue);
@@ -37,6 +38,7 @@ export const Switch = withSwitchVariation(
         duration={200}
       >
         <PressableBox
+          id={id}
           as="button"
           role="switch"
           ariaChecked={isChecked}

--- a/packages/vibrant-components/src/lib/Switch/SwitchProps.ts
+++ b/packages/vibrant-components/src/lib/Switch/SwitchProps.ts
@@ -2,6 +2,7 @@ import type { ResponsiveValue } from '@vibrant-ui/core';
 import { propVariant, withVariation } from '@vibrant-ui/core';
 
 export type SwitchProps = {
+  id?: string;
   size?: ResponsiveValue<'md' | 'sm'>;
   defaultValue?: boolean;
   onValueChange?: (state: boolean) => void;

--- a/packages/vibrant-core/src/lib/PressableBox/PressableBoxProps.ts
+++ b/packages/vibrant-core/src/lib/PressableBox/PressableBoxProps.ts
@@ -40,6 +40,7 @@ export type PressableBoxProps = {
   onHoverIn?: () => void;
   onHoverOut?: () => void;
   children?: ReactElementChild | ReactElementChild[];
+  id?: string;
   role?: Role;
   ariaLabel?: string;
   ariaSelected?: boolean;


### PR DESCRIPTION
https://github.com/pedaling/opensource/pull/787 의 변경사항으로 Pressable 내부 구현에서 최상단에 위치한 컴포넌트가 Transition이 되었는데 Transition이 중첩되서 쓰이면서 switch에서의 Trasition 스타일이 적용되지 않는 이슈로 스위치의 backgroundColor가 보이지 않았습니다. Pressable -> PressableBox를 사용해서 이슈를 해결했습니다.
(+ 덤으로 접근성을 위한 프로퍼티들을 추가해줬어요)

<img width="44" alt="image" src="https://github.com/pedaling/opensource/assets/37496919/416235d2-701c-408c-80e5-27e3e5b8b697">
