### PR TITLE
fix: chromatic 배포 메모리 할당을 늘린다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_TOKEN }}
           autoAcceptChanges: true
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
 
   # expo:
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
배포 중 oom이 발생해서 할당을 늘립니다