### PR TITLE
fix: popover qa issues

### DIFF
--- a/packages/vibrant-components/src/lib/Popover/Popover.tsx
+++ b/packages/vibrant-components/src/lib/Popover/Popover.tsx
@@ -264,15 +264,7 @@ export const Popover = ({
               <VStack px={12} py={8} ref={popoverRef} width="100%" height="100%">
                 <HStack flex={1} alignHorizontal="space-between" onLayout={() => calcuratePositionValue(position)}>
                   {isDefined(title) && (
-                    <HStack
-                      {...(!isNative
-                        ? {
-                            flex: 1,
-                            flexGrow: 1,
-                            overflow: 'hidden',
-                          }
-                        : {})}
-                    >
+                    <HStack overflow={isNative ? 'visible' : 'hidden'}>
                       <Body
                         level={2}
                         weight="regular"


### PR DESCRIPTION
### title이 지정되었을 때 영문은 단어단위, 한글은 글자단위로 래핑된다. [CPPT-110](https://101inc.atlassian.net/browse/CPPT-110)

https://github.com/pedaling/opensource/assets/100175974/094dd95c-626c-4bc1-a50e-546a3a9108f7

### Popover가 열려있을 때 열리기 전의 클릭 영역과 같지 않다 [CPPT-187](https://101inc.atlassian.net/browse/CPPT-187)

https://github.com/pedaling/opensource/assets/100175974/854c44ab-b09e-4906-af2b-df4911e320cc

### arrowOffset의 동작이 방향에 따라 상이하다 [CPPT-188](https://101inc.atlassian.net/browse/CPPT-188)

https://github.com/pedaling/opensource/assets/100175974/a5caf74e-4769-43a6-8747-658b13eb16d9

- arrow가 Popover를 벗어나지 않도록 수정

### Popover가 Native에서 동작하도록 변경한다 [CPPT-189](https://101inc.atlassian.net/browse/CPPT-189)

https://github.com/pedaling/opensource/assets/100175974/bdf9d637-aa34-4ef6-98a8-4b4842cede17


[CPPT-110]: https://101inc.atlassian.net/browse/CPPT-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CPPT-187]: https://101inc.atlassian.net/browse/CPPT-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CPPT-188]: https://101inc.atlassian.net/browse/CPPT-188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CPPT-189]: https://101inc.atlassian.net/browse/CPPT-189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ