### PR TITLE
fix: handle maxWidth, rounded prop properly in SkeletonImage

### DIFF
--- a/packages/vibrant-components/src/lib/Skeleton/SkeletonImage/SkeletonImage.tsx
+++ b/packages/vibrant-components/src/lib/Skeleton/SkeletonImage/SkeletonImage.tsx
@@ -2,8 +2,10 @@ import { Box } from '@vibrant-ui/core';
 import { Ratio } from '../../Ratio';
 import { withSkeletonImageVariation } from './SkeletonImageProps';
 
-export const SkeletonImage = withSkeletonImageVariation(({ width = '100%', ratio }) => (
-  <Ratio width={width} ratio={ratio}>
-    <Box backgroundColor="disable" rounded="sm" width="100%" height="100%" />
-  </Ratio>
-));
+export const SkeletonImage = withSkeletonImageVariation(
+  ({ width = '100%', ratio, maxWidth, rounded = 'sm', ...props }) => (
+    <Ratio width={width} ratio={ratio} maxWidth={maxWidth}>
+      <Box backgroundColor="disable" width="100%" height="100%" rounded={rounded} {...props} />
+    </Ratio>
+  )
+);

--- a/packages/vibrant-components/src/lib/Skeleton/SkeletonImage/SkeletonImageProps.ts
+++ b/packages/vibrant-components/src/lib/Skeleton/SkeletonImage/SkeletonImageProps.ts
@@ -1,7 +1,7 @@
 import type { BorderSystemProps, ResponsiveValue } from '@vibrant-ui/core';
 import { withVariation } from '@vibrant-ui/core';
 
-export type SkeletonImageProps = Pick<BorderSystemProps, 'borderRadiusLevel'> & {
+export type SkeletonImageProps = Pick<BorderSystemProps, 'borderRadiusLevel' | 'rounded'> & {
   width: ResponsiveValue<number | `${number}%`>;
   ratio: ResponsiveValue<number>;
   maxWidth?: ResponsiveValue<number | `${number}%`>;


### PR DESCRIPTION
SkeletonImage에서 rounded 속성을 받을 수 있게 추가하고, 외부에서 maxWidth, rounded, borderRadiusLevel 속성을 통해 해당 값들을 조절할 수 있도록 합니다. 
(그동안 이 값들이 안넘겨지고 있어서 속성으로 넘겨줘도 동작하지 않고 있었습니다 ..)

<img width="1145" alt="image" src="https://github.com/pedaling/opensource/assets/37496919/14c4a4b1-7ad7-4997-a20a-e50dd398c8b6">
