### PR TITLE
fix: reset table style to remove stripe pattern

### DIFF
--- a/packages/vibrant-website/src/css/custom.tsx
+++ b/packages/vibrant-website/src/css/custom.tsx
@@ -15,11 +15,14 @@ const style = theme => css`
     --ifm-pre-background: ${theme.colors.background};
     --ifm-code-font-size: 80%;
     --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+    --ifm-table-stripe-background: rgba(0, 0, 0, 0);
   }
   /* If you have a different syntax highlighting theme for dark mode. */
   [data-theme='dark'] {
     /* Color which works with dark mode syntax highlighting theme */
     --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+    --ifm-table-stripe-background: var(--ifm-pre-background);
+    --ifm-table-background: var(--ifm-pre-background);
   }
 
   .docusaurus-highlight-code-line {


### PR DESCRIPTION
## Before
<img width="586" alt="스크린샷 2023-08-08 오후 1 45 43" src="https://github.com/pedaling/opensource/assets/105209178/29bb128c-0ecd-448c-9366-dbbfaa2fa857">

## After
<img width="616" alt="스크린샷 2023-08-08 오후 1 44 41" src="https://github.com/pedaling/opensource/assets/105209178/4f0d84a8-d173-40b4-bf68-e63e5c78ea53">
