### PR TITLE
fix: Drawer내에서 중복된 로직을 제거합니다.

### DIFF
--- a/packages/vibrant-components/src/lib/Drawer/Drawer.tsx
+++ b/packages/vibrant-components/src/lib/Drawer/Drawer.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import { Children, useEffect, useState } from 'react';
+import { Children, useState } from 'react';
 import type { LayoutEvent } from '@vibrant-ui/core';
 import { Box, PressableBox, ScrollBox } from '@vibrant-ui/core';
 import { Transition } from '@vibrant-ui/motion';
@@ -44,14 +44,6 @@ export const Drawer = ({
   const closePanel = () => setIsPanelOpen(false);
 
   const { ref: drawerRef } = useEscapeEvent(closePanel);
-
-  useEffect(() => {
-    if (isPanelOpen) {
-      onOpen?.();
-    } else {
-      onClose?.();
-    }
-  }, [isPanelOpen, onClose, onOpen]);
 
   const onContainerLayout = ({ width, height }: LayoutEvent) => {
     const isVertical = placement === 'left' || placement === 'right';


### PR DESCRIPTION
### 변경사항
* useEffect 내에서 동작하던 onClose, onOpen이 `useControllableState` 의 onValueChange에 이미 있어서 중복된 라인을 제거합니다.