### PR TITLE
feat: modalBottomSheet을 숨길 수 있는 prop 추가

### DIFF
--- a/packages/vibrant-components/src/lib/Backdrop/Backdrop.tsx
+++ b/packages/vibrant-components/src/lib/Backdrop/Backdrop.tsx
@@ -15,6 +15,7 @@ export const Backdrop = withBackdropVariation(
     onDismiss,
     scrollable,
     testId = 'backdrop',
+    display,
     ...restProps
   }) => {
     const [isMount, setIsMount] = useState(open);
@@ -54,6 +55,7 @@ export const Backdrop = withBackdropVariation(
           backgroundColor={color}
           scrollable={scrollable}
           data-testid={testId}
+          display={display}
         >
           <KeyboardAvoidingBox>
             <Box flex={1} {...restProps}>

--- a/packages/vibrant-components/src/lib/Backdrop/BackdropProps.ts
+++ b/packages/vibrant-components/src/lib/Backdrop/BackdropProps.ts
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import type { ResponsiveValue, SpacingSystemProps } from '@vibrant-ui/core';
+import type { DisplaySystemProps, ResponsiveValue, SpacingSystemProps } from '@vibrant-ui/core';
 import { withVariation } from '@vibrant-ui/core';
 import type { ColorToken } from '@vibrant-ui/theme';
 
@@ -13,6 +13,7 @@ type BackdropProps = {
   onClick?: () => void;
   onDismiss?: () => void;
   testId?: string;
-} & Pick<SpacingSystemProps, 'p' | 'pb' | 'pl' | 'pr' | 'pt' | 'px' | 'py'>;
+} & Pick<SpacingSystemProps, 'p' | 'pb' | 'pl' | 'pr' | 'pt' | 'px' | 'py'> &
+  Pick<DisplaySystemProps, 'display'>;
 
 export const withBackdropVariation = withVariation<BackdropProps>('Backdrop')();

--- a/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.tsx
+++ b/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.tsx
@@ -42,6 +42,7 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
     dimClosable = true,
     testId = 'modal-bottom-sheet',
     scrollBoxRef,
+    dangerouslyHideOverlayOnIos,
   }) => {
     const [isOpen, setIsOpen] = useControllableState<boolean>({
       value: open,
@@ -123,6 +124,7 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
                 setContainerHeight(undefined);
               }
             }}
+            display={dangerouslyHideOverlayOnIos ? 'none' : 'flex'}
           >
             <Transition
               animation={{

--- a/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheetProps.ts
+++ b/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheetProps.ts
@@ -20,6 +20,7 @@ export type ModalBottomSheetProps = Either<
   showCloseButton?: boolean;
   dimClosable?: boolean;
   scrollBoxRef?: Ref<any>;
+  dangerouslyHideOverlayOnIos?: boolean;
 } & (
     | {
         primaryButtonOptions: ButtonOptions;


### PR DESCRIPTION
ios Portal에 FullWindowOverlay를 사용하고 있어서 항상 최상단에 뜨고 있습니다
모달이 네이티브 Image Picker보다 앞에 뜨는 문제를 수정하기 위해서 Prop을 추가했습니다

![IMG_0093](https://github.com/pedaling/opensource/assets/68044498/883b4845-71a8-44b8-a01a-525b19a412c4)
