### PR TITLE
fix: hide table header when data is empty

### DIFF
--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -155,7 +155,8 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
               <TableHeaderCell renderCell={() => <Box width={16} height={16} />} width={48} />
             )}
             {!loading
-              ? columns.map(
+              ? data.length > 0 &&
+                columns.map(
                   ({
                     key,
                     dataKey,


### PR DESCRIPTION
CC-3637

resolve #873 

|before| after|
|---|---|
|<img width="801" alt="before-table-header" src="https://github.com/pedaling/opensource/assets/96866599/e102be9b-f8a8-47a8-819b-39aa406fd48d"> | <img width="980" alt="after-table-header" src="https://github.com/pedaling/opensource/assets/96866599/930deba1-9ed0-419e-a875-436a6c413ce4">|
