### PR TITLE
fix: Dropdown issue that py value is not applied when the value is 0

### DIFF
--- a/packages/vibrant-components/src/lib/Dropdown/Dropdown.tsx
+++ b/packages/vibrant-components/src/lib/Dropdown/Dropdown.tsx
@@ -265,7 +265,7 @@ export const Dropdown = withDropdownVariation(
                 <Box alignSelf="flex-start">
                   <Box
                     backgroundColor="surface2"
-                    py={py !== undefined ? py : CONTENT_PADDING}
+                    py={isDefined(py) ? py : CONTENT_PADDING}
                     elevationLevel={4}
                     rounded="md"
                     minWidth={[280, 280, 240]}


### PR DESCRIPTION
- Dropdown에서 py값이 0일 때 적용되지 않던 문제를 수정했습니다.