### PR TITLE
fix: helper text can be react node

### DIFF
--- a/packages/vibrant-components/src/lib/TextField/TextFieldProps.ts
+++ b/packages/vibrant-components/src/lib/TextField/TextFieldProps.ts
@@ -1,4 +1,4 @@
-import type { ForwardedRef, ReactElement } from 'react';
+import type { ForwardedRef, ReactNode } from 'react';
 import type {
   AutoCapitalizeOption,
   AutoCompleteOption,
@@ -18,7 +18,7 @@ export type TextFieldProps = BaseInputProps<string> &
     state?: 'default' | 'error';
     label?: string;
     placeholder?: string;
-    helperText?: ReactElement | string;
+    helperText?: ReactNode | string;
     autoFocus?: boolean;
     maxLength?: number;
     autoComplete?: AutoCompleteOption;


### PR DESCRIPTION
* localizeText(..., { variable }) 의 type이 `string | reactNodeArray` 으로, reactElement로는 커버할 수 없어서 수정이 필요합니다.