### PR TITLE
fix: popover maxWidth 동작하지 않는 이슈 수정

### DIFF
--- a/packages/vibrant-components/src/lib/Popover/Popover.tsx
+++ b/packages/vibrant-components/src/lib/Popover/Popover.tsx
@@ -1,5 +1,5 @@
 import { cloneElement, useCallback, useEffect, useRef, useState } from 'react';
-import { Box, isNative, useCurrentTheme, usePopover, useResponsiveValue } from '@vibrant-ui/core';
+import { Box, getWindowDimensions, isNative, useCurrentTheme, usePopover, useResponsiveValue } from '@vibrant-ui/core';
 import { Icon } from '@vibrant-ui/icons';
 import { Transition } from '@vibrant-ui/motion';
 import { getElementRect, isDefined, useCallbackRef } from '@vibrant-ui/utils';
@@ -43,13 +43,20 @@ export const Popover = ({
     top: 0,
   });
   const [arrowStyle, setArrowStyle] = useState({});
+  const { width: viewportWidth } = getWindowDimensions();
   const computedOffset = getResponsiveValue(offset);
+  const computedMaxWidth = getResponsiveValue(maxWidth);
 
   const popoverRef = useRef<HTMLElement>(null);
   const childRef = useRef<HTMLElement>(null);
   const handleOpen = useCallbackRef(onOpen);
   const handleClose = useCallbackRef(onClose);
 
+  const popoverWidth = computedMaxWidth
+    ? typeof computedMaxWidth === 'number'
+      ? Math.min(viewportWidth, computedMaxWidth)
+      : computedMaxWidth
+    : '100%';
   const arrowHeight = Math.sqrt(ARROW_TRIANGLE_SIZE * ARROW_TRIANGLE_SIZE * 2) / 2;
 
   const calcuratePositionValue = useCallback(
@@ -252,9 +259,9 @@ export const Popover = ({
 
   return (
     <VStack>
-      <VStack position="fixed">
+      <VStack position="absolute">
         <Transition animation={{ opacity: isOpen ? 1 : 0, ...popoverPosition }} duration={200} easing="easeOutQuad">
-          <VStack zIndex={isOpen ? zIndex ?? themeZIndex.popover : 0} maxWidth={maxWidth} width="100%">
+          <VStack zIndex={isOpen ? zIndex ?? themeZIndex.popover : 0} width={popoverWidth}>
             <Paper backgroundColor={backgroundColor} rounded="sm">
               <VStack px={12} py={8} ref={popoverRef} width="100%" height="100%">
                 <HStack flex={1} alignHorizontal="space-between">


### PR DESCRIPTION
#### maxWidth 180

<img width="1657" alt="스크린샷 2023-11-03 오전 11 09 07" src="https://github.com/pedaling/opensource/assets/100175974/20c8280f-039c-4dec-bc68-7d8e4a7ec1dc">

#### maxWidth 320

<img width="1656" alt="스크린샷 2023-11-03 오전 11 09 22" src="https://github.com/pedaling/opensource/assets/100175974/8c58c340-d6b7-4bc4-ac94-3001dd7bb028">

#### maxWidth 480

<img width="1657" alt="스크린샷 2023-11-03 오전 11 09 37" src="https://github.com/pedaling/opensource/assets/100175974/2a8afcd7-540b-49f3-a507-6fc20d41461d">

#### maxWidth undefined

<img width="1661" alt="스크린샷 2023-11-03 오전 11 10 05" src="https://github.com/pedaling/opensource/assets/100175974/daf1f07a-e68f-42aa-845b-c2b17fc81625">

#### maxWidth Number.MAX_SAFE_INTEGER

<img width="1661" alt="스크린샷 2023-11-03 오전 11 11 04" src="https://github.com/pedaling/opensource/assets/100175974/e761cca2-2b01-429e-9676-3675562ec212">

<br/>

- Popover에서 maxWidth 동작하도록 변경합니다