### PR TITLE
feat: update callout layout and typography

### DIFF
--- a/packages/vibrant-components/src/lib/Callout/Callout.stories.tsx
+++ b/packages/vibrant-components/src/lib/Callout/Callout.stories.tsx
@@ -8,6 +8,7 @@ export default {
   args: {
     title: '타이틀을 입력하세요',
     kind: 'warning',
+    contents: '콘텐츠를 입력하세요',
     buttonText: 'Action',
     onButtonClick: () => {},
   },

--- a/packages/vibrant-components/src/lib/Callout/Callout.tsx
+++ b/packages/vibrant-components/src/lib/Callout/Callout.tsx
@@ -1,6 +1,7 @@
-import { Box, Text } from '@vibrant-ui/core';
-import { ContainedButton } from '../ContainedButton';
+import { Box } from '@vibrant-ui/core';
 import { HStack } from '../HStack';
+import { OutlinedButton } from '../OutlinedButton';
+import { Paragraph } from '../Paragraph';
 import { Title } from '../Title';
 import { VStack } from '../VStack';
 import { withCalloutVariation } from './CalloutProps';
@@ -24,41 +25,34 @@ export const Callout = withCalloutVariation(
       borderWidth={1}
       borderColor="outline1"
       rounded="sm"
-      p={15}
+      px={16}
+      py={8}
       data-testid={testId}
     >
-      <HStack spacing={6}>
-        <Box mt={1}>
-          <IconComponent.Fill fill={fontColor} size={16} />
+      <HStack spacing={12}>
+        <Box py={8}>
+          <IconComponent.Fill fill={fontColor} size={14} />
         </Box>
-        <Title level={7} weight="bold" color={fontColor} overflowWrap="anywhere">
-          {title}
-        </Title>
-      </HStack>
-      <VStack mt={8}>
-        {contents ? (
-          <Text
-            color="onView1"
-            mb={contents ? 2 : 0}
-            lineHeight={18}
-            fontSize={14}
-            fontWeight="regular"
-            flex={1}
-            overflowWrap="anywhere"
-          >
-            {contents}
-          </Text>
-        ) : (
-          renderContents?.()
-        )}
-      </VStack>
-      {buttonText ? (
-        <VStack alignHorizontal="end" mt={12}>
-          <ContainedButton onClick={onButtonClick} size="md" kind="tertiary">
-            {buttonText}
-          </ContainedButton>
+        <VStack py={6} spacing={8}>
+          <Title level={7} weight="bold" color="onView1" overflowWrap="anywhere">
+            {title}
+          </Title>
+          {contents ? (
+            <Paragraph level={4} color="onView1" overflowWrap="anywhere">
+              {contents}
+            </Paragraph>
+          ) : (
+            renderContents?.()
+          )}
+          {buttonText ? (
+            <VStack alignHorizontal="start">
+              <OutlinedButton onClick={onButtonClick} size="sm">
+                {buttonText}
+              </OutlinedButton>
+            </VStack>
+          ) : null}
         </VStack>
-      ) : null}
+      </HStack>
     </Box>
   )
 );

--- a/packages/vibrant-components/src/lib/Callout/CalloutProps.ts
+++ b/packages/vibrant-components/src/lib/Callout/CalloutProps.ts
@@ -44,7 +44,7 @@ export const withCalloutVariation = withVariation<CalloutProps>('Callout')(
       error: {
         backgroundColor: 'errorContainer',
         fontColor: 'onViewError',
-        IconComponent: Icon.Alert,
+        IconComponent: Icon.AlertCircle,
       },
       warning: {
         backgroundColor: 'warningContainer',


### PR DESCRIPTION
<img width="892" alt="스크린샷 2023-11-13 오후 12 47 30" src="https://github.com/pedaling/opensource/assets/99634272/46f9abff-ffc8-42f5-8e8a-07feffdfb453">
<img width="856" alt="스크린샷 2023-11-13 오후 12 47 01" src="https://github.com/pedaling/opensource/assets/99634272/a97d3e8f-567d-4900-ac90-dce85ed73746">

- Callout 컴포넌트의 Typography, layout, 및 icon을 변경합니다.

Jira: https://101inc.atlassian.net/browse/CC-3761