### PR TITLE
fix: contents area of CallOut Component

### DIFF
--- a/packages/vibrant-components/src/lib/Callout/Callout.tsx
+++ b/packages/vibrant-components/src/lib/Callout/Callout.tsx
@@ -33,7 +33,7 @@ export const Callout = withCalloutVariation(
         <Box py={8}>
           <IconComponent.Fill fill={fontColor} size={14} />
         </Box>
-        <VStack py={6} spacing={8}>
+        <VStack py={6} spacing={8} width="100%">
           <Title level={7} weight="bold" color="onView1" overflowWrap="anywhere">
             {title}
           </Title>


### PR DESCRIPTION
## Before
<img width="887" alt="스크린샷 2023-11-16 오후 6 11 15" src="https://github.com/pedaling/opensource/assets/99634272/9bc0a920-de09-4355-95f0-58ca9da5ed18">

## After
<img width="862" alt="스크린샷 2023-11-16 오후 6 10 54" src="https://github.com/pedaling/opensource/assets/99634272/cc29200c-e2c2-4299-91d7-7ea484dc21dc">
