### PR TITLE
fix: 모바싯을 native에서 여는 경우 window객체 접근을 막는다

### DIFF
--- a/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.tsx
+++ b/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.tsx
@@ -116,7 +116,7 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
     }, [containerHeight]);
 
     useEffect(() => {
-      if (typeof window === 'undefined' || !isOpen || (!dimClosable && !showCloseButton)) {
+      if (typeof window === 'undefined' || isNative || !isOpen || (!dimClosable && !showCloseButton)) {
         return;
       }
 


### PR DESCRIPTION
- native에서 접근하는 경우 typeof window === 'undefined'에 걸리지 않고 object로 와서 isNative 조건을 추가했습니다