### PR TITLE
fix: react-native useWindowDimensions 호출 횟수를 줄인다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ buck-out/
 
 
 packages/vibrant-benchmark-app-e2e/artifacts
+.nx

--- a/packages/vibrant-core/src/lib/WindowDimensionsProvider/WindowDimensionsProvider.native.tsx
+++ b/packages/vibrant-core/src/lib/WindowDimensionsProvider/WindowDimensionsProvider.native.tsx
@@ -1,6 +1,16 @@
+import { createContext, useContext } from 'react';
 import type { FC, ReactElement } from 'react';
-import { useWindowDimensions as useReactNativeWindowDimensions } from 'react-native';
+import { Dimensions, useWindowDimensions as useReactNativeWindowDimensions } from 'react-native';
+import type { WindowDimensionsContextValue } from './WindowDimensionsProviderProps';
 
-export const WindowDimensionsProvider: FC<{ children: ReactElement }> = ({ children }) => children;
+const initialWindowDimensions = Dimensions.get('window');
 
-export const useWindowDimensions = () => useReactNativeWindowDimensions();
+const WindowDimensionsContext = createContext<WindowDimensionsContextValue>(initialWindowDimensions);
+
+export const WindowDimensionsProvider: FC<{ children: ReactElement }> = ({ children }) => {
+  const windowDimensions = useReactNativeWindowDimensions();
+
+  return <WindowDimensionsContext.Provider value={windowDimensions}>{children}</WindowDimensionsContext.Provider>;
+};
+
+export const useWindowDimensions = () => useContext(WindowDimensionsContext);


### PR DESCRIPTION
# Background

react-native에서 제공하는 useWindowDimensions는 내부적으로 event listener를 추가하여서 화면의 너비가 바뀔때마다 state가 업데이트가 되는데, 우리는 Box 별로 useWindowDimension을 사용하다보니 수강환경 기준으로 리스너가 5000개정도 등록이 된다. 이때 문제점이 화면 회전이 될 때 리스너가 하나씩 호출이 되어서 state가 한번에 업데이트 되는게 아니라 각각 별도로 업데이트가 되고, 이로 인해서 가로회전이 엄청나게 느린 문제가 생겼습니다 

이제 enableFreeze와 함께 사용하면 홈 화면 리랜더링이 완전히 방지되어서 수강환경 화면회전이 개발 환경 기준 30배정도 빨라졌습니다

[참고 메모](https://www.notion.so/class101/4-31523cd397b44484a65a86f2c3a68d55?pvs=4#0eb5bb315aa34b1899f6c1e9c82e3bc9)

## 변경사항

- rn에서 제공하는 useWindowDimension을 최상위에서만 호출되도록 하고 각 뷰에서는 context에서 제공하는 값을 사용하도록 했습니다