### PR TITLE
fix: change CallOut title font weight to medium

### DIFF
--- a/packages/vibrant-components/src/lib/Callout/Callout.tsx
+++ b/packages/vibrant-components/src/lib/Callout/Callout.tsx
@@ -34,7 +34,7 @@ export const Callout = withCalloutVariation(
           <IconComponent.Fill fill={fontColor} size={14} />
         </Box>
         <VStack py={6} spacing={8} width="100%">
-          <Title level={7} weight="bold" color="onView1" overflowWrap="anywhere">
+          <Title level={7} weight="medium" color="onView1" overflowWrap="anywhere">
             {title}
           </Title>
           {contents ? (


### PR DESCRIPTION
Jira: https://101inc.atlassian.net/browse/CC-3868

- Callout title의 font weight을 `bold` -> `medium`으로 변경합니다
