### PR TITLE
refactor: change Paper, ContentArea chileren type to ReactElementChildren

### DIFF
--- a/packages/vibrant-components/src/lib/ContentArea/ContentAreaProps.ts
+++ b/packages/vibrant-components/src/lib/ContentArea/ContentAreaProps.ts
@@ -1,9 +1,9 @@
-import type { ReactElementChild, ResponsiveValue } from '@vibrant-ui/core';
+import type { ReactElementChildren, ResponsiveValue } from '@vibrant-ui/core';
 import { withVariation } from '@vibrant-ui/core';
 
 export type ContentAreaProps = {
   padding?: ResponsiveValue<boolean>;
-  children: ReactElementChild;
+  children: ReactElementChildren;
   testId?: string;
 };
 

--- a/packages/vibrant-components/src/lib/Paper/PaperProps.ts
+++ b/packages/vibrant-components/src/lib/Paper/PaperProps.ts
@@ -8,7 +8,7 @@ import type {
   InteractionSystemProps,
   OverflowSystemProps,
   PositionSystemProps,
-  ReactElementChild,
+  ReactElementChildren,
   ResponsiveValue,
   SizingSystemProps,
   SpacingSystemProps,
@@ -48,7 +48,7 @@ type PaperProps = Pick<BorderSystemProps, 'borderColor' | 'borderStyle' | 'borde
     ref?: Ref<any>;
     id?: string;
     as?: BoxElements;
-    children?: ReactElementChild;
+    children?: ReactElementChildren;
     testId?: string;
   } & Either<
     Pick<BorderSystemProps, 'roundedBottomLeft' | 'roundedBottomRight' | 'roundedTopLeft' | 'roundedTopRight'>,


### PR DESCRIPTION
Paper나 ContentArea 내에 여러 요소를 렌더링하려면 VStack이나 Fragment로 감싸줘야하는 번거로움이 있어서 children 타입을 허용해줍니다