### PR TITLE
fix: transform scale 사용 시 값 뒤에 px이 붙는 이슈를 수정한다

### DIFF
--- a/packages/vibrant-core/src/lib/props/transform/transform.ts
+++ b/packages/vibrant-core/src/lib/props/transform/transform.ts
@@ -1,8 +1,8 @@
 import { isDefined } from '@vibrant-ui/utils';
 import { createSystemProp } from '../../createSystemProp';
 
-function getTransformValue(value: number | string) {
-  if (typeof value === 'number') {
+function getTransformValue(key: string, value: number | string) {
+  if (typeof value === 'number' && key !== 'scale' && key !== 'scaleX' && key !== 'scaleY') {
     return `${value}px`;
   }
 
@@ -14,7 +14,7 @@ const transformProp = createSystemProp({
   transform: value => {
     const style = Object.keys(value)
       .filter(key => isDefined(value[key]))
-      .reduce((style, key) => `${style} ${key}(${getTransformValue(value[key])})`, '')
+      .reduce((style, key) => `${style} ${key}(${getTransformValue(key, value[key])})`, '')
       .trim();
 
     return {


### PR DESCRIPTION
scale 값으로 숫자를 넘겨주는 경우 px 단위가 뒤에 붙는데 scale의 경우는 px 없이 배수를 인수로 넘겨야하기 때문에 px을 붙이지 않도록 처리해줍니다