### PR TITLE
fix: 이미지썸네일 aspectRatio를 responsiveValue로 변경한다

### DIFF
--- a/packages/vibrant-components/src/lib/ImageThumbnail/ImageThumbnailProps.ts
+++ b/packages/vibrant-components/src/lib/ImageThumbnail/ImageThumbnailProps.ts
@@ -3,7 +3,7 @@ import { withVariation } from '@vibrant-ui/core';
 
 export type ImageThumbnailProps = {
   dim?: ResponsiveValue<boolean>;
-  aspectRatio: number;
+  aspectRatio: ResponsiveValue<number>;
   testId?: string;
 } & Pick<ImageProps, 'alt' | 'loading' | 'objectFit' | 'rounded' | 'sizes' | 'src' | 'width'>;
 


### PR DESCRIPTION
ImageThumbnail 컴포넌트의 aspectRatio prop을 responsiveValue로 변경했습니다