### PR TITLE
fix: 모바일 디바이스에서 Pressable 터치 시 hover interaction이 남아 있는 이슈를 수정한다

### DIFF
--- a/packages/vibrant-core/src/lib/PressableBox/PressableBox.tsx
+++ b/packages/vibrant-core/src/lib/PressableBox/PressableBox.tsx
@@ -33,8 +33,8 @@ export const PressableBox = withPressableBoxVariation(
 
         onClick?.();
       }}
-      onMouseEnter={() => onHoverIn?.()}
-      onMouseLeave={() => onHoverOut?.()}
+      onPointerOver={() => onHoverIn?.()}
+      onPointerOut={() => onHoverOut?.()}
       onFocus={() => onFocusIn?.()}
       onBlur={() => onFocusOut?.()}
       onMouseDown={() => onPressIn?.()}


### PR DESCRIPTION
onMouseEnter 이벤트는 터치 시에 트리거되고 onMouseLeave는 이후에 다른 영역 터치 시 트리거되고 있어서, Pressable 터치 시 hover interaction color가 남아 있게 되는 버그 발생해서 onMouseEnter/onMouseLeave이 아닌 onPointerOver/onPointerOut 이벤트를 사용합니다. ([참고](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#event_types_and_global_event_handlers))

### Before

https://github.com/pedaling/opensource/assets/37496919/5b830131-fbee-4279-86e5-be39bcc2bdf1



### After

https://github.com/pedaling/opensource/assets/37496919/378b9102-36e3-48f0-bbbe-1858a1faacf7

