### PR TITLE
fix : android에서 popoverHeight,popoverWidth가 undefined일때 0으로 변경한다

### DIFF
--- a/packages/vibrant-components/src/lib/Popover/Popover.tsx
+++ b/packages/vibrant-components/src/lib/Popover/Popover.tsx
@@ -60,7 +60,7 @@ export const Popover = ({
 
   const calculatePositionValue = useCallback(
     async (position: Position) => {
-      const { width: popoverWidth, height: popoverHeight = 0 } = await getElementRect(popoverRef.current);
+      const { width: popoverWidth = 0, height: popoverHeight = 0 } = await getElementRect(popoverRef.current);
       const { width: childWidth, height: childHeight } = await getElementRect(childRef.current);
 
       const halfPopoverWidth = popoverWidth / 2;


### PR DESCRIPTION
android에서 popoverHeight,popoverWidth가 undefined일때 0으로 변경해주어서 계산식에서 Nan이 들어가지 않도록 변경한다.