### PR TITLE
fix: popover가 특정 위치에서 안보이는 문제를 수정한다

### DIFF
--- a/packages/vibrant-components/src/lib/Popover/Popover.tsx
+++ b/packages/vibrant-components/src/lib/Popover/Popover.tsx
@@ -243,7 +243,7 @@ export const Popover = ({
       <VStack position="absolute" zIndex={containerZIndex}>
         <Transition
           animation={{
-            opacity: isOpen && popoverPosition.x !== 0 && popoverPosition.y !== 0 ? 1 : 0,
+            opacity: isOpen && (popoverPosition.x !== 0 || popoverPosition.y !== 0) ? 1 : 0,
             ...popoverPosition,
           }}
           duration={200}


### PR DESCRIPTION
![screen](https://github.com/pedaling/opensource/assets/32216112/5259e26b-ae20-4fb5-904f-b76b9456f487)

x가 0일때 안나오는 문제를 수정했어요