### PR TITLE
fix: set gap in ScrollBox contentContainerStyle

### DIFF
--- a/packages/vibrant-core/src/lib/ScrollBox/ScrollBox.native.tsx
+++ b/packages/vibrant-core/src/lib/ScrollBox/ScrollBox.native.tsx
@@ -47,6 +47,9 @@ export const ScrollBox = styled(
         paddingTop,
         paddingVertical,
         paddingHorizontal,
+        gap,
+        rowGap,
+        columnGap,
         ...restStyle
       } = StyleSheet.flatten(style);
 
@@ -68,6 +71,9 @@ export const ScrollBox = styled(
             paddingTop,
             paddingVertical,
             paddingHorizontal,
+            gap,
+            rowGap,
+            columnGap,
           }}
           access={true}
           accessibilityLabel={ariaLabel}


### PR DESCRIPTION
ScrollBox에 contentContainerStyle에 gap 속성을 넘겨줘서 컨테이너 내 아이템 간격을 설정할 수 있게 합니다

### before

![Simulator Screen Shot - iPhone 14 - 2024-03-11 at 19 35 18](https://github.com/pedaling/opensource/assets/37496919/6824d58d-cd0e-41f3-84ca-2f88a9a13f6d)

### after

![Simulator Screen Shot - iPhone 14 - 2024-03-11 at 19 35 26](https://github.com/pedaling/opensource/assets/37496919/952fd973-614d-4c14-b161-0060ddbfbd6d)

