### PR TITLE
fix: 팝오버의 포지션 값에 애니메이션이 적용되지 않게 수정한다

### DIFF
--- a/packages/vibrant-components/src/lib/Popover/Popover.stories.tsx
+++ b/packages/vibrant-components/src/lib/Popover/Popover.stories.tsx
@@ -24,6 +24,16 @@ export const Basic: ComponentStory<typeof Popover> = props => (
   </VStack>
 );
 
+export const WithDefaultOpen: ComponentStory<typeof Popover> = props => (
+  <VStack width="100%" height="100vh" alignVertical="center" alignHorizontal="center">
+    <Popover title="Popover" {...props} open={true}>
+      <Popover.Opener openInteraction="click">
+        <Avatar size="lg" src="" alt="" />
+      </Popover.Opener>
+    </Popover>
+  </VStack>
+);
+
 export const WithExternalState: ComponentStory<typeof Popover> = props => {
   const [isOpen, setIsOpen] = useState(false);
 

--- a/packages/vibrant-components/src/lib/Popover/Popover.tsx
+++ b/packages/vibrant-components/src/lib/Popover/Popover.tsx
@@ -244,8 +244,8 @@ export const Popover = ({
         <Transition
           animation={{
             opacity: isOpen && (popoverPosition.x !== 0 || popoverPosition.y !== 0) ? 1 : 0,
-            ...popoverPosition,
           }}
+          style={popoverPosition}
           duration={200}
           easing="easeOutQuad"
         >


### PR DESCRIPTION
## Before
https://github.com/pedaling/opensource/assets/33626219/2227a881-1b89-4ce9-b83f-0ccf7ca19475

## After
https://github.com/pedaling/opensource/assets/33626219/bdfd10ac-5aa2-453f-8887-e4c1a283bab2

