### PR TITLE
feat: popover can fixed to the right

### DIFF
--- a/packages/vibrant-components/src/lib/Popover/Popover.tsx
+++ b/packages/vibrant-components/src/lib/Popover/Popover.tsx
@@ -31,6 +31,7 @@ export const Popover = ({
   zIndex,
   onClose,
   onOpen,
+  fix,
 }: PopoverProps) => {
   const { isOpen, open: openPopover, close: closePopover } = usePopover({ id: popoverId, value: open });
   const {
@@ -57,6 +58,7 @@ export const Popover = ({
       : computedMaxWidth
     : '100%';
   const arrowHeight = Math.sqrt(ARROW_TRIANGLE_SIZE * ARROW_TRIANGLE_SIZE * 2) / 2;
+  const rightFixed = fix === 'right';
 
   const calculatePositionValue = useCallback(
     async (position: Position) => {
@@ -77,12 +79,12 @@ export const Popover = ({
       if (position.includes('top')) {
         if (position === 'top') {
           setPopoverPosition({
-            x: halfChildWidth - halfPopoverWidth,
+            x: rightFixed ? 0 : halfChildWidth - halfPopoverWidth,
             y: -popoverHeight - arrowHeight - computedOffset,
           });
 
           setArrowPosition({
-            left: halfPopoverWidth - arrowHeight,
+            left: rightFixed ? arrowRightMaxDistance - positiveArrowOffset : halfPopoverWidth - arrowHeight,
             top: popoverHeight - arrowHeight - 2,
           });
         }
@@ -115,12 +117,12 @@ export const Popover = ({
       if (position.includes('bottom')) {
         if (position === 'bottom') {
           setPopoverPosition({
-            x: halfChildWidth - halfPopoverWidth,
+            x: rightFixed ? 0 : halfChildWidth - halfPopoverWidth,
             y: childHeight + arrowHeight + computedOffset,
           });
 
           setArrowPosition({
-            left: halfPopoverWidth - arrowHeight,
+            left: rightFixed ? arrowRightMaxDistance - positiveArrowOffset : halfPopoverWidth - arrowHeight,
             top: -arrowHeight,
           });
         }
@@ -244,7 +246,7 @@ export const Popover = ({
 
   return (
     <VStack zIndex={containerZIndex}>
-      <VStack position="absolute" zIndex={containerZIndex}>
+      <VStack position="absolute" zIndex={containerZIndex} right={rightFixed ? 0 : undefined}>
         <Transition
           animation={{
             opacity: isOpen && (popoverPosition.x !== 0 || popoverPosition.y !== 0) ? 1 : 0,

--- a/packages/vibrant-components/src/lib/Popover/Popover.tsx
+++ b/packages/vibrant-components/src/lib/Popover/Popover.tsx
@@ -58,7 +58,7 @@ export const Popover = ({
       : computedMaxWidth
     : '100%';
   const arrowHeight = Math.sqrt(ARROW_TRIANGLE_SIZE * ARROW_TRIANGLE_SIZE * 2) / 2;
-  const rightFixed = fix === 'right';
+  const fixedRight = fix === 'right';
 
   const calculatePositionValue = useCallback(
     async (position: Position) => {
@@ -79,12 +79,12 @@ export const Popover = ({
       if (position.includes('top')) {
         if (position === 'top') {
           setPopoverPosition({
-            x: rightFixed ? 0 : halfChildWidth - halfPopoverWidth,
+            x: fixedRight ? 0 : halfChildWidth - halfPopoverWidth,
             y: -popoverHeight - arrowHeight - computedOffset,
           });
 
           setArrowPosition({
-            left: rightFixed ? arrowRightMaxDistance - positiveArrowOffset : halfPopoverWidth - arrowHeight,
+            left: fixedRight ? arrowRightMaxDistance - positiveArrowOffset : halfPopoverWidth - arrowHeight,
             top: popoverHeight - arrowHeight - 2,
           });
         }
@@ -117,12 +117,12 @@ export const Popover = ({
       if (position.includes('bottom')) {
         if (position === 'bottom') {
           setPopoverPosition({
-            x: rightFixed ? 0 : halfChildWidth - halfPopoverWidth,
+            x: fixedRight ? 0 : halfChildWidth - halfPopoverWidth,
             y: childHeight + arrowHeight + computedOffset,
           });
 
           setArrowPosition({
-            left: rightFixed ? arrowRightMaxDistance - positiveArrowOffset : halfPopoverWidth - arrowHeight,
+            left: fixedRight ? arrowRightMaxDistance - positiveArrowOffset : halfPopoverWidth - arrowHeight,
             top: -arrowHeight,
           });
         }
@@ -246,7 +246,7 @@ export const Popover = ({
 
   return (
     <VStack zIndex={containerZIndex}>
-      <VStack position="absolute" zIndex={containerZIndex} right={rightFixed ? 0 : undefined}>
+      <VStack position="absolute" zIndex={containerZIndex} right={fixedRight ? 0 : undefined}>
         <Transition
           animation={{
             opacity: isOpen && (popoverPosition.x !== 0 || popoverPosition.y !== 0) ? 1 : 0,

--- a/packages/vibrant-components/src/lib/Popover/PopoverProps.ts
+++ b/packages/vibrant-components/src/lib/Popover/PopoverProps.ts
@@ -4,9 +4,6 @@ import type { BaseColorToken } from '@vibrant-ui/theme';
 import type { Position } from '@vibrant-ui/utils';
 
 export type PopoverProps = {
-  title?: string;
-  renderContent?: () => ReactElement;
-  position: Position;
   showCloseButton?: boolean;
   backgroundColor?: BaseColorToken;
   maxWidth?: ResponsiveValue<number | `${number}%`>;
@@ -17,8 +14,13 @@ export type PopoverProps = {
   children?: ReactElement;
   popoverId?: string;
   zIndex?: ResponsiveValue<number>;
-} & ({ title: string; renderContent?: () => ReactElement } | { title?: string; renderContent: () => ReactElement }) &
-  PopoverArrowType;
+} & PopoverContent &
+  PopoverArrowType &
+  PopoverPosition;
+
+type PopoverContent =
+  | { title: string; renderContent?: () => ReactElement }
+  | { title?: string; renderContent: () => ReactElement };
 
 type PopoverArrowType =
   | {
@@ -28,4 +30,14 @@ type PopoverArrowType =
   | {
       showArrow?: true;
       arrowOffset?: number;
+    };
+
+type PopoverPosition =
+  | {
+      position: 'bottom' | 'top';
+      fix?: 'right';
+    }
+  | {
+      position: Exclude<Position, 'bottom' | 'top'>;
+      fix?: never;
     };


### PR DESCRIPTION
before 
<img width="541" alt="스크린샷 2025-02-25 오후 9 18 07" src="https://github.com/user-attachments/assets/99c69905-fa8b-433f-9409-fe1908d7075a" />

after  ( When the component's `fix` prop is set to `right` )
<img width="590" alt="스크린샷 2025-02-25 오후 9 18 51" src="https://github.com/user-attachments/assets/8d9bda98-5cdc-4d78-b278-7525d29ae517" />
