### PR TITLE
fix: delete popover unused space

### DIFF
--- a/packages/vibrant-components/src/lib/Popover/Popover.stories.tsx
+++ b/packages/vibrant-components/src/lib/Popover/Popover.stories.tsx
@@ -3,7 +3,9 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import { Avatar } from '../Avatar';
 import { Body } from '../Body';
 import { ContainedButton } from '../ContainedButton';
+import { HStack } from '../HStack';
 import { VStack } from '../VStack';
+
 import { Popover } from './Popover';
 
 export default {
@@ -15,12 +17,30 @@ export default {
 } as ComponentMeta<typeof Popover>;
 
 export const Basic: ComponentStory<typeof Popover> = props => (
-  <VStack width="100%" height="100vh" alignVertical="center" alignHorizontal="center">
-    <Popover title="Popover" {...props}>
-      <Popover.Opener openInteraction="click">
-        <Avatar size="lg" src="" alt="" />
-      </Popover.Opener>
-    </Popover>
+  <VStack spacing={20} width="100%" my={20}>
+    <HStack width="100%" height={100} alignVertical="center" alignHorizontal="center">
+      <Popover title="Popover" {...props}>
+        <Popover.Opener openInteraction="click">
+          <Avatar size="lg" src="" alt="" />
+        </Popover.Opener>
+      </Popover>
+      <HStack flex={1} />
+    </HStack>
+    <HStack width="100%" height={100} alignVertical="center" alignHorizontal="center">
+      <HStack flex={1} />
+      <Popover title="Popover" {...props}>
+        <Popover.Opener openInteraction="click">
+          <Avatar size="lg" src="" alt="" />
+        </Popover.Opener>
+      </Popover>
+    </HStack>
+    <HStack width="100%" height={100} alignVertical="center" alignHorizontal="center">
+      <Popover title="Popover" {...props}>
+        <Popover.Opener openInteraction="click">
+          <Avatar size="lg" src="" alt="" />
+        </Popover.Opener>
+      </Popover>
+    </HStack>
   </VStack>
 );
 

--- a/packages/vibrant-components/src/lib/Popover/Popover.tsx
+++ b/packages/vibrant-components/src/lib/Popover/Popover.tsx
@@ -242,7 +242,7 @@ export const Popover = ({
 
   const containerZIndex = isOpen ? zIndex ?? themeZIndex.popover : 0;
 
-  const absolutePosition = useMemo(() => {
+  const absolutePositionStyle = useMemo(() => {
     if (position.startsWith('top') || position.startsWith('bottom')) {
       if (position.endsWith('end')) {
         return { right: 0 };
@@ -258,7 +258,7 @@ export const Popover = ({
 
   return (
     <VStack zIndex={containerZIndex}>
-      <VStack position="absolute" zIndex={containerZIndex} {...absolutePosition}>
+      <VStack position="absolute" zIndex={containerZIndex} {...absolutePositionStyle}>
         <Transition
           animation={{
             opacity: isOpen && (popoverPosition.x !== 0 || popoverPosition.y !== 0) ? 1 : 0,

--- a/packages/vibrant-components/src/lib/Popover/Popover.tsx
+++ b/packages/vibrant-components/src/lib/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, useCallback, useEffect, useRef, useState } from 'react';
+import { cloneElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, getWindowDimensions, isNative, useCurrentTheme, usePopover, useResponsiveValue } from '@vibrant-ui/core';
 import { Icon } from '@vibrant-ui/icons';
 import { Transition } from '@vibrant-ui/motion';
@@ -101,7 +101,7 @@ export const Popover = ({
 
         if (position === 'top-end') {
           setPopoverPosition({
-            x: -popoverWidth + childWidth,
+            x: 0,
             y: -popoverHeight - arrowHeight - computedOffset,
           });
 
@@ -139,7 +139,7 @@ export const Popover = ({
 
         if (position === 'bottom-end') {
           setPopoverPosition({
-            x: -popoverWidth + childWidth,
+            x: 0,
             y: childHeight + arrowHeight + computedOffset,
           });
 
@@ -242,9 +242,23 @@ export const Popover = ({
 
   const containerZIndex = isOpen ? zIndex ?? themeZIndex.popover : 0;
 
+  const absolutePosition = useMemo(() => {
+    if (position.startsWith('top') || position.startsWith('bottom')) {
+      if (position.endsWith('end')) {
+        return { right: 0 };
+      }
+
+      if (position.endsWith('start')) {
+        return { left: 0 };
+      }
+    }
+
+    return {};
+  }, [position]);
+
   return (
     <VStack zIndex={containerZIndex}>
-      <VStack position="absolute" zIndex={containerZIndex}>
+      <VStack position="absolute" zIndex={containerZIndex} {...absolutePosition}>
         <Transition
           animation={{
             opacity: isOpen && (popoverPosition.x !== 0 || popoverPosition.y !== 0) ? 1 : 0,


### PR DESCRIPTION
before 
<img width="340" alt="스크린샷 2025-02-27 오후 9 32 11" src="https://github.com/user-attachments/assets/7a39c0d7-f7c0-4394-9b8a-3c85eac37c20" />


after
<img width="319" alt="스크린샷 2025-02-27 오후 9 32 45" src="https://github.com/user-attachments/assets/1390cb2f-7d0d-43bf-aa16-74adb8463d2f" />
