### PR TITLE
feat(vibrant-components): table multi cells selection and copy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
     "javascriptreact",
     "typescript",
     "typescriptreact"
-  ]
+  ],
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/vibrant-components/src/lib/Table/Table.stories.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.stories.tsx
@@ -145,9 +145,9 @@ export const SelectableInteractiveTable: FC<ComponentProps<typeof Table> & { loc
   };
 
   const deleteRow = (data: Data) => () => {
-    const corresRowKey = data[props.rowKey];
+    const corresRowKey = data[props.rowKey as keyof Data];
 
-    setData(prev => prev.filter(row => row[props.rowKey] !== corresRowKey));
+    setData(prev => prev.filter(row => row[props.rowKey as keyof Data] !== corresRowKey));
   };
 
   return (
@@ -191,7 +191,7 @@ export const SelectableInteractiveTable: FC<ComponentProps<typeof Table> & { loc
   );
 };
 
-export const cellSelectable: ComponentStory<typeof Table> = props => (
+export const CellSelectable: ComponentStory<typeof Table> = props => (
   <Box p={20} width="100%">
     <Table {...props} selectable={false}>
       <Table.Column<Data>

--- a/packages/vibrant-components/src/lib/Table/Table.stories.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.stories.tsx
@@ -245,6 +245,56 @@ export const CellSelectable: ComponentStory<typeof Table> = props => (
   </Box>
 );
 
+export const MultiCellSelectable: ComponentStory<typeof Table> = props => (
+  <Box p={20} width="100%">
+    <Table {...props} multiCellSelectable={true}>
+      <Table.Column<Data>
+        key="name"
+        dataKey="name"
+        renderHeader={() => <OutlinedButton size="sm">이름 수정</OutlinedButton>}
+        onDataCell={{
+          onClick: action('onDateCellClick'),
+          onCopy: action('onDataCellCopy'),
+        }}
+      />
+      <Table.Column<Data>
+        key="calories"
+        dataKey="calories"
+        title="calories"
+        onDataCell={{
+          onClick: action('onDateCellClick'),
+          onCopy: action('onDataCellCopy'),
+        }}
+      />
+      <Table.Column<Data> key="fat" dataKey="fat" title="fat" description="abc" />
+      <Table.Column<Data>
+        key="carbs"
+        dataKey="carbs"
+        title="carbs"
+        onDataCell={{
+          onClick: action('onDateCellClick'),
+          onCopy: action('onDataCellCopy'),
+        }}
+      />
+      <Table.Column<Data>
+        key="protein"
+        dataKey="protein"
+        title="protein"
+        onDataCell={{
+          onClick: action('onDateCellClick'),
+          onCopy: action('onDataCellCopy'),
+        }}
+      />
+      <Table.Column<Data>
+        key="Edit"
+        title=""
+        width={120}
+        renderDataCell={() => <OutlinedButton size="sm">삭제</OutlinedButton>}
+      />
+    </Table>
+  </Box>
+);
+
 export const Empty: ComponentStory<typeof Table> = ({ emptyImage, emptyText }) => (
   <Box p={20} width="100%">
     <Table rowKey="name" data={[]} emptyText={emptyText} emptyImage={emptyImage}>

--- a/packages/vibrant-components/src/lib/Table/Table.stories.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.stories.tsx
@@ -265,6 +265,7 @@ export const MultiCellSelectable: ComponentStory<typeof Table> = props => (
           onClick: action('onDateCellClick'),
           onCopy: action('onDataCellCopy'),
         }}
+        sortable={true}
       />
       <Table.Column<Data> key="fat" dataKey="fat" title="fat" description="abc" />
       <Table.Column<Data>

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -159,7 +159,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
 
     const clipboardText = selectedCells.join('\n');
 
-    navigator.clipboard.writeText(clipboardText);
+    navigator?.clipboard.writeText(clipboardText);
   };
 
   const handleToggleCheckbox = (key: Data[RowKey]) => {

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -194,6 +194,10 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
 
     const selectedCells = [];
 
+    const columnNames = columns.slice(startCol, endCol + 1).map(column => column.title || column.dataKey || '');
+
+    selectedCells.push(columnNames.join('\t'));
+
     for (let rowIdx = startRow; rowIdx <= endRow; rowIdx++) {
       const row = data[rowIdx];
       const rowCells = columns.slice(startCol, endCol + 1).map(column => {

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -303,18 +303,21 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
               <TableHeaderCell renderCell={() => <Box width={16} height={16} />} width={48} />
             )}
             {columns.map(
-              ({
-                key,
-                dataKey,
-                alignHorizontal,
-                alignVertical,
-                renderHeader,
-                lineLimit,
-                wordBreak,
-                whiteSpace,
-                overflowWrap,
-                ...column
-              }: TableColumnProps<Data>) => (
+              (
+                {
+                  key,
+                  dataKey,
+                  alignHorizontal,
+                  alignVertical,
+                  renderHeader,
+                  lineLimit,
+                  wordBreak,
+                  whiteSpace,
+                  overflowWrap,
+                  ...column
+                }: TableColumnProps<Data>,
+                colIdx
+              ) => (
                 <TableHeaderCell
                   key={key}
                   {...column}
@@ -327,6 +330,26 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                   renderCell={renderHeader}
                   sortDirection={sortBy.dataKey === dataKey ? sortBy.direction : 'none'}
                   onSort={(sortDirection: SortDirection) => handleChangeSort({ dataKey, direction: sortDirection })}
+                  onPressIn={() => {
+                    setIsSelectingRange(true);
+                    setSelectedRange(prev => ({
+                      anchor: isShiftKeyPressed && prev ? prev.anchor : { rowIdx: 0, colIdx },
+                      cursor: { rowIdx: data.length - 1, colIdx },
+                    }));
+                  }}
+                  onPressOut={() => {
+                    setIsSelectingRange(false);
+                  }}
+                  onHoverIn={() => {
+                    if (!isSelectingRange) {
+                      return;
+                    }
+
+                    setSelectedRange(prev => ({
+                      anchor: prev ? prev.anchor : { rowIdx: 0, colIdx },
+                      cursor: { rowIdx: data.length - 1, colIdx },
+                    }));
+                  }}
                 />
               )
             )}

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -175,19 +175,19 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
     };
   }, [multiCellSelectable]);
 
-  const [isShiftKeyPressed, setIsShiftKeyPressed] = useState(false);
+  const isShiftKeyPressed = useRef(false);
 
   // Shift 키 누르고 있는 동안에만 range 선택 가능
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Shift') {
-        setIsShiftKeyPressed(true);
+        isShiftKeyPressed.current = true;
       }
     };
 
     const handleKeyUp = (event: KeyboardEvent) => {
       if (event.key === 'Shift') {
-        setIsShiftKeyPressed(false);
+        isShiftKeyPressed.current = false;
       }
     };
 
@@ -360,7 +360,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                     setIsSelectingRange(true);
                     setSelectedRange(prev => ({
                       anchor:
-                        isShiftKeyPressed && !selectingRangeFromCell && prev
+                        isShiftKeyPressed.current && !selectingRangeFromCell && prev
                           ? { rowIdx: 0, colIdx: prev.anchor.colIdx }
                           : { rowIdx: 0, colIdx },
                       cursor: { rowIdx: data.length - 1, colIdx },
@@ -437,7 +437,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                           setSelectingRangeFromCell(true);
                           setIsSelectingRange(true);
                           setSelectedRange(prev => ({
-                            anchor: isShiftKeyPressed && prev ? prev.anchor : { rowIdx, colIdx },
+                            anchor: isShiftKeyPressed.current && prev ? prev.anchor : { rowIdx, colIdx },
                             cursor: { rowIdx, colIdx },
                           }));
                         }}

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -358,7 +358,10 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                     setSelectingRangeFromCell(false);
                     setIsSelectingRange(true);
                     setSelectedRange(prev => ({
-                      anchor: isShiftKeyPressed && prev ? prev.anchor : { rowIdx: 0, colIdx },
+                      anchor:
+                        isShiftKeyPressed && !selectingRangeFromCell && prev
+                          ? { rowIdx: 0, colIdx: prev.anchor.colIdx }
+                          : { rowIdx: 0, colIdx },
                       cursor: { rowIdx: data.length - 1, colIdx },
                     }));
                   }}

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -354,6 +354,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                   renderCell={renderHeader}
                   sortDirection={sortBy.dataKey === dataKey ? sortBy.direction : 'none'}
                   onSort={(sortDirection: SortDirection) => handleChangeSort({ dataKey, direction: sortDirection })}
+                  multiCellSelectable={multiCellSelectable}
                   onPressIn={() => {
                     setSelectingRangeFromCell(false);
                     setIsSelectingRange(true);

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -92,6 +92,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
   const isCellClickEnabled = columns?.some(column => isDefined(column.onDataCell));
 
   const [selectedRange, setSelectedRange] = useState<TableCellRange>();
+  const [isSelectingRange, setIsSelectingRange] = useState(false);
 
   const isCellInSelectedRange = (rowIdx: number, colIdx: number) => {
     if (!selectedRange) {
@@ -309,9 +310,17 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                             : undefined
                         }
                         onPressIn={() => {
+                          setIsSelectingRange(true);
                           setSelectedRange({ anchor: { rowIdx, colIdx }, cursor: { rowIdx, colIdx } });
                         }}
                         onPressOut={() => {
+                          setIsSelectingRange(false);
+                        }}
+                        onHoverIn={() => {
+                          if (!isSelectingRange) {
+                            return;
+                          }
+
                           setSelectedRange(prev => ({
                             anchor: prev ? prev.anchor : { rowIdx, colIdx },
                             cursor: { rowIdx, colIdx }

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable max-lines */
 /* eslint-disable @typescript-eslint/naming-convention */
 import type { ReactElement } from 'react';
 import { Children, isValidElement, useEffect, useMemo, useState } from 'react';

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -16,6 +16,7 @@ import type { TableColumnProps } from './TableColumn/TableColumnProps';
 import { TableDataCell } from './TableDataCell';
 import type { TableDataCellProps } from './TableDataCell/TableDataCellProps';
 import { TableHeaderCell } from './TableHeaderCell';
+import type { TableHeaderCellProps } from './TableHeaderCell/TableHeaderCellProps';
 import type { TableCellRange, TableProps, TableSortBy, UseTableResult } from './TableProps';
 import { TableRow } from './TableRow';
 import type { SortDirection } from './TableSortIcon';
@@ -125,10 +126,28 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
     const startCol = Math.min(anchor.colIdx, cursor.colIdx);
     const endCol = Math.max(anchor.colIdx, cursor.colIdx);
 
-    cellOnEdge.top = rowIdx === startRow && colIdx >= startCol && colIdx <= endCol;
+    cellOnEdge.top = rowIdx === startRow && colIdx >= startCol && colIdx <= endCol && selectingRangeFromCell;
     cellOnEdge.bottom = rowIdx === endRow && colIdx >= startCol && colIdx <= endCol;
     cellOnEdge.left = colIdx === startCol && rowIdx >= startRow && rowIdx <= endRow;
     cellOnEdge.right = colIdx === endCol && rowIdx >= startRow && rowIdx <= endRow;
+
+    return cellOnEdge;
+  };
+
+  const isHeaderOnEdgeOfSelectedRange = (colIdx: number) => {
+    const cellOnEdge: TableHeaderCellProps['selectedOnEdge'] = { left: true, right: true };
+
+    if (!multiCellSelectable || !selectedRange) {
+      return cellOnEdge;
+    }
+
+    const { anchor, cursor } = selectedRange;
+
+    const startCol = Math.min(anchor.colIdx, cursor.colIdx);
+    const endCol = Math.max(anchor.colIdx, cursor.colIdx);
+
+    cellOnEdge.left = colIdx === startCol;
+    cellOnEdge.right = colIdx === endCol;
 
     return cellOnEdge;
   };
@@ -356,6 +375,8 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                       cursor: { rowIdx: selectingRangeFromCell ? 0 : data.length - 1, colIdx },
                     }));
                   }}
+                  selected={!selectingRangeFromCell && isCellInSelectedRange(0, colIdx)}
+                  selectedOnEdge={isHeaderOnEdgeOfSelectedRange(colIdx)}
                 />
               )
             )}

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable max-lines */
 /* eslint-disable @typescript-eslint/naming-convention */
 import type { ReactElement } from 'react';
-import { Children, isValidElement, useEffect, useMemo, useRef, useState } from 'react';
+import { Children, isValidElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Image, ScrollBox, isNative, useConfig } from '@vibrant-ui/core';
 import { isDefined, useControllableState } from '@vibrant-ui/utils';
 import { Body } from '../Body';
@@ -217,7 +217,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
     };
   }, []);
 
-  const copySelectedCells = () => {
+  const copySelectedCells = useCallback(() => {
     if (!selectedRange) {
       return;
     }
@@ -244,7 +244,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
     const clipboardText = selectedCells.join('\n');
 
     navigator?.clipboard.writeText(clipboardText);
-  };
+  }, [columns, data, selectedRange]);
 
   const handleToggleCheckbox = (key: Data[RowKey]) => {
     const newSelectedRowKeys = new Set(selectedRowKeys);

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -322,28 +322,30 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                     <Paper backgroundColor="surface1" p={16}>
                       {renderExpanded?.(row)}
                     </Paper>
-                    /* eslint-disable prettier/prettier */
-                    )}
-                    expanded={expandedRowKeys?.includes(row[rowKey])}
-                    disabled={disabledRowKeys?.includes(row[rowKey])}
-                  >
-                    {columns.map(
-                    ({
-                      key,
-                      dataKey,
-                      alignHorizontal,
-                      alignVertical,
-                      lineLimit,
-                      wordBreak,
-                      whiteSpace,
-                      overflowWrap,
-                      onDataCell,
-                      formatData,
-                      renderDataCell,
-                      selectable: cellSelectable,
-                      width: _,
-                      ...column
-                    }: TableColumnProps<Data>, colIdx) => (
+                  )}
+                  expanded={expandedRowKeys?.includes(row[rowKey])}
+                  disabled={disabledRowKeys?.includes(row[rowKey])}
+                >
+                  {columns.map(
+                    (
+                      {
+                        key,
+                        dataKey,
+                        alignHorizontal,
+                        alignVertical,
+                        lineLimit,
+                        wordBreak,
+                        whiteSpace,
+                        overflowWrap,
+                        onDataCell,
+                        formatData,
+                        renderDataCell,
+                        selectable: cellSelectable,
+                        width: _,
+                        ...column
+                      }: TableColumnProps<Data>,
+                      colIdx
+                    ) => (
                       <TableDataCell
                         key={key}
                         onClick={() => {
@@ -357,8 +359,8 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                         onPressIn={() => {
                           setIsSelectingRange(true);
                           setSelectedRange(prev => ({
-                          anchor: isShiftKeyPressed && prev ? prev.anchor : { rowIdx, colIdx },
-                          cursor: { rowIdx, colIdx }
+                            anchor: isShiftKeyPressed && prev ? prev.anchor : { rowIdx, colIdx },
+                            cursor: { rowIdx, colIdx },
                           }));
                         }}
                         onPressOut={() => {
@@ -366,17 +368,17 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                         }}
                         onHoverIn={() => {
                           if (!isSelectingRange) {
-                          return;
+                            return;
                           }
 
                           setSelectedRange(prev => ({
-                          anchor: prev ? prev.anchor : { rowIdx, colIdx },
-                          cursor: { rowIdx, colIdx }
+                            anchor: prev ? prev.anchor : { rowIdx, colIdx },
+                            cursor: { rowIdx, colIdx },
                           }));
                         }}
                         onCopy={() => {
                           if (!multiCellSelectable) {
-                          onDataCell?.onCopy?.(row);
+                            onDataCell?.onCopy?.(row);
                           }
                         }}
                         alignVertical={alignVertical?.dataCell}
@@ -392,9 +394,9 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                         }
                         renderCell={renderDataCell ? () => renderDataCell?.(row) : undefined}
                         {...column}
-                        >
+                      >
                         {isDefined(formatData) ? formatData(row) : dataKey ? row[dataKey] : null}
-                        </TableDataCell>
+                      </TableDataCell>
                     )
                   )}
                 </TableRow>

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import type { ReactElement } from 'react';
 import { Children, isValidElement, useEffect, useMemo, useRef, useState } from 'react';
-import { Box, Image, ScrollBox, useConfig } from '@vibrant-ui/core';
+import { Box, Image, ScrollBox, isNative, useConfig } from '@vibrant-ui/core';
 import { isDefined, useControllableState } from '@vibrant-ui/utils';
 import { Body } from '../Body';
 import { GhostButton } from '../GhostButton';
@@ -179,6 +179,10 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
 
   // Shift 키 누르고 있는 동안에만 range 선택 가능
   useEffect(() => {
+    if (isNative) {
+      return;
+    }
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Shift') {
         isShiftKeyPressed.current = true;

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -23,6 +23,17 @@ import type { SortDirection } from './TableSortIcon';
 
 const getCellKey = (key: any, rowIndex: number) => `${key}:${rowIndex}`;
 
+const getCornersFromSelectedRange = (selectedRange: TableCellRange) => {
+  const { anchor, cursor } = selectedRange;
+
+  return {
+    startRow: Math.min(anchor.rowIdx, cursor.rowIdx),
+    endRow: Math.max(anchor.rowIdx, cursor.rowIdx),
+    startCol: Math.min(anchor.colIdx, cursor.colIdx),
+    endCol: Math.max(anchor.colIdx, cursor.colIdx),
+  };
+};
+
 const isCellInSelectedRange = (
   rowIdx: number,
   colIdx: number,
@@ -33,12 +44,7 @@ const isCellInSelectedRange = (
     return false;
   }
 
-  const { anchor, cursor } = selectedRange;
-
-  const startRow = Math.min(anchor.rowIdx, cursor.rowIdx);
-  const endRow = Math.max(anchor.rowIdx, cursor.rowIdx);
-  const startCol = Math.min(anchor.colIdx, cursor.colIdx);
-  const endCol = Math.max(anchor.colIdx, cursor.colIdx);
+  const { startRow, endRow, startCol, endCol } = getCornersFromSelectedRange(selectedRange);
 
   return rowIdx >= startRow && rowIdx <= endRow && colIdx >= startCol && colIdx <= endCol;
 };
@@ -56,12 +62,7 @@ const isCellOnEdgeOfSelectedRange = (
     return cellOnEdge;
   }
 
-  const { anchor, cursor } = selectedRange;
-
-  const startRow = Math.min(anchor.rowIdx, cursor.rowIdx);
-  const endRow = Math.max(anchor.rowIdx, cursor.rowIdx);
-  const startCol = Math.min(anchor.colIdx, cursor.colIdx);
-  const endCol = Math.max(anchor.colIdx, cursor.colIdx);
+  const { startRow, endRow, startCol, endCol } = getCornersFromSelectedRange(selectedRange);
 
   cellOnEdge.top = rowIdx === startRow && colIdx >= startCol && colIdx <= endCol && selectingRangeFromCell;
   cellOnEdge.bottom = rowIdx === endRow && colIdx >= startCol && colIdx <= endCol;
@@ -82,10 +83,7 @@ const isHeaderOnEdgeOfSelectedRange = (
     return cellOnEdge;
   }
 
-  const { anchor, cursor } = selectedRange;
-
-  const startCol = Math.min(anchor.colIdx, cursor.colIdx);
-  const endCol = Math.max(anchor.colIdx, cursor.colIdx);
+  const { startCol, endCol } = getCornersFromSelectedRange(selectedRange);
 
   cellOnEdge.left = colIdx === startCol;
   cellOnEdge.right = colIdx === endCol;
@@ -224,12 +222,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
       return;
     }
 
-    const { anchor, cursor } = selectedRange;
-
-    const startRow = Math.min(anchor.rowIdx, cursor.rowIdx);
-    const endRow = Math.max(anchor.rowIdx, cursor.rowIdx);
-    const startCol = Math.min(anchor.colIdx, cursor.colIdx);
-    const endCol = Math.max(anchor.colIdx, cursor.colIdx);
+    const { startRow, endRow, startCol, endCol } = getCornersFromSelectedRange(selectedRange);
 
     const selectedCells = [];
 

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -103,7 +103,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
   rowKey,
   loading = false,
   selectable = false,
-  multiCellSelectable = false,
+  multiCellSelectable = true,
   selectButtons,
   onSelectionChange,
   renderExpanded,

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -93,8 +93,8 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
   const [selectedCellKey, setSelectedCellKey] = useState<string>();
   const isCellClickEnabled = columns?.some(column => isDefined(column.onDataCell));
 
+  const isSelectingRange = useRef(false);
   const [selectedRange, setSelectedRange] = useState<TableCellRange>();
-  const [isSelectingRange, setIsSelectingRange] = useState(false);
   const [selectingRangeFromCell, setSelectingRangeFromCell] = useState(true);
 
   const isCellInSelectedRange = (rowIdx: number, colIdx: number) => {
@@ -357,7 +357,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                   multiCellSelectable={multiCellSelectable}
                   onPressIn={() => {
                     setSelectingRangeFromCell(false);
-                    setIsSelectingRange(true);
+                    isSelectingRange.current = true;
                     setSelectedRange(prev => ({
                       anchor:
                         isShiftKeyPressed.current && !selectingRangeFromCell && prev
@@ -367,10 +367,10 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                     }));
                   }}
                   onPressOut={() => {
-                    setIsSelectingRange(false);
+                    isSelectingRange.current = false;
                   }}
                   onHoverIn={() => {
-                    if (!isSelectingRange) {
+                    if (!isSelectingRange.current) {
                       return;
                     }
 
@@ -435,17 +435,17 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                         }}
                         onPressIn={() => {
                           setSelectingRangeFromCell(true);
-                          setIsSelectingRange(true);
+                          isSelectingRange.current = true;
                           setSelectedRange(prev => ({
                             anchor: isShiftKeyPressed.current && prev ? prev.anchor : { rowIdx, colIdx },
                             cursor: { rowIdx, colIdx },
                           }));
                         }}
                         onPressOut={() => {
-                          setIsSelectingRange(false);
+                          isSelectingRange.current = false;
                         }}
                         onHoverIn={() => {
-                          if (!isSelectingRange) {
+                          if (!isSelectingRange.current) {
                             return;
                           }
 

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -94,6 +94,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
 
   const [selectedRange, setSelectedRange] = useState<TableCellRange>();
   const [isSelectingRange, setIsSelectingRange] = useState(false);
+  const [selectingRangeFromCell, setSelectingRangeFromCell] = useState(true);
 
   const isCellInSelectedRange = (rowIdx: number, colIdx: number) => {
     if (!multiCellSelectable || !selectedRange) {
@@ -335,6 +336,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                   sortDirection={sortBy.dataKey === dataKey ? sortBy.direction : 'none'}
                   onSort={(sortDirection: SortDirection) => handleChangeSort({ dataKey, direction: sortDirection })}
                   onPressIn={() => {
+                    setSelectingRangeFromCell(false);
                     setIsSelectingRange(true);
                     setSelectedRange(prev => ({
                       anchor: isShiftKeyPressed && prev ? prev.anchor : { rowIdx: 0, colIdx },
@@ -351,7 +353,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
 
                     setSelectedRange(prev => ({
                       anchor: prev ? prev.anchor : { rowIdx: 0, colIdx },
-                      cursor: { rowIdx: data.length - 1, colIdx },
+                      cursor: { rowIdx: selectingRangeFromCell ? 0 : data.length - 1, colIdx },
                     }));
                   }}
                 />
@@ -407,6 +409,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                           }
                         }}
                         onPressIn={() => {
+                          setSelectingRangeFromCell(true);
                           setIsSelectingRange(true);
                           setSelectedRange(prev => ({
                             anchor: isShiftKeyPressed && prev ? prev.anchor : { rowIdx, colIdx },
@@ -423,7 +426,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
 
                           setSelectedRange(prev => ({
                             anchor: prev ? prev.anchor : { rowIdx, colIdx },
-                            cursor: { rowIdx, colIdx },
+                            cursor: { rowIdx: selectingRangeFromCell ? rowIdx : data.length - 1, colIdx },
                           }));
                         }}
                         onCopy={() => {

--- a/packages/vibrant-components/src/lib/Table/TableDataCell/TableDataCell.tsx
+++ b/packages/vibrant-components/src/lib/Table/TableDataCell/TableDataCell.tsx
@@ -15,6 +15,7 @@ export const TableDataCell = withTableDataCellVariation(
     onClick,
     onPressIn,
     onPressOut,
+    onHoverIn,
     onCopy,
     renderCell,
     alignHorizontal = 'center',
@@ -47,6 +48,7 @@ export const TableDataCell = withTableDataCellVariation(
         onClick={onClick}
         onPressIn={onPressIn}
         onPressOut={onPressOut}
+        onHoverIn={onHoverIn}
         disabled={disabled || !isDefined(onClick)}
         cursor={disabled || !isDefined(onClick) ? 'default' : 'pointer'}
         borderBottomStyle="solid"

--- a/packages/vibrant-components/src/lib/Table/TableDataCell/TableDataCell.tsx
+++ b/packages/vibrant-components/src/lib/Table/TableDataCell/TableDataCell.tsx
@@ -24,6 +24,7 @@ export const TableDataCell = withTableDataCellVariation(
     color,
     disabled,
     selected,
+    selectedOnEdge,
   }) => {
     const handleCopyEvent = () => {
       if (typeof navigator === 'undefined' || children === undefined || children === null) {
@@ -66,6 +67,10 @@ export const TableDataCell = withTableDataCellVariation(
               borderWidth={1}
               borderStyle="solid"
               borderColor="outlineInformative"
+              borderLeftWidth={selectedOnEdge?.left ? 1 : 0}
+              borderRightWidth={selectedOnEdge?.right ? 1 : 0}
+              borderTopWidth={selectedOnEdge?.top ? 1 : 0}
+              borderBottomWidth={selectedOnEdge?.bottom ? 1 : 0}
             />
           )}
           {rowSelected && (

--- a/packages/vibrant-components/src/lib/Table/TableDataCell/TableDataCell.tsx
+++ b/packages/vibrant-components/src/lib/Table/TableDataCell/TableDataCell.tsx
@@ -67,6 +67,7 @@ export const TableDataCell = withTableDataCellVariation(
               borderWidth={1}
               borderStyle="solid"
               borderColor="outlineInformative"
+              backgroundColor="informativeContainer"
               borderLeftWidth={selectedOnEdge?.left ? 1 : 0}
               borderRightWidth={selectedOnEdge?.right ? 1 : 0}
               borderTopWidth={selectedOnEdge?.top ? 1 : 0}

--- a/packages/vibrant-components/src/lib/Table/TableDataCell/TableDataCell.tsx
+++ b/packages/vibrant-components/src/lib/Table/TableDataCell/TableDataCell.tsx
@@ -13,6 +13,8 @@ export const TableDataCell = withTableDataCellVariation(
     overflowWrap,
     whiteSpace,
     onClick,
+    onPressIn,
+    onPressOut,
     onCopy,
     renderCell,
     alignHorizontal = 'center',
@@ -43,6 +45,8 @@ export const TableDataCell = withTableDataCellVariation(
         px={16}
         width={width}
         onClick={onClick}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
         disabled={disabled || !isDefined(onClick)}
         cursor={disabled || !isDefined(onClick) ? 'default' : 'pointer'}
         borderBottomStyle="solid"

--- a/packages/vibrant-components/src/lib/Table/TableDataCell/TableDataCellProps.ts
+++ b/packages/vibrant-components/src/lib/Table/TableDataCell/TableDataCellProps.ts
@@ -13,6 +13,7 @@ export type TableDataCellProps = {
   onClick?: () => void;
   onPressIn?: () => void;
   onPressOut?: () => void;
+  onHoverIn?: () => void;
   onCopy?: () => void;
   alignVertical?: 'center' | 'end' | 'start';
   alignHorizontal?: 'center' | 'end' | 'start';

--- a/packages/vibrant-components/src/lib/Table/TableDataCell/TableDataCellProps.ts
+++ b/packages/vibrant-components/src/lib/Table/TableDataCell/TableDataCellProps.ts
@@ -11,6 +11,8 @@ export type TableDataCellProps = {
   children?: TextChildren;
   renderCell?: () => ReactElementChildren;
   onClick?: () => void;
+  onPressIn?: () => void;
+  onPressOut?: () => void;
   onCopy?: () => void;
   alignVertical?: 'center' | 'end' | 'start';
   alignHorizontal?: 'center' | 'end' | 'start';

--- a/packages/vibrant-components/src/lib/Table/TableDataCell/TableDataCellProps.ts
+++ b/packages/vibrant-components/src/lib/Table/TableDataCell/TableDataCellProps.ts
@@ -19,6 +19,7 @@ export type TableDataCellProps = {
   alignHorizontal?: 'center' | 'end' | 'start';
   disabled?: boolean;
   selected?: boolean;
+  selectedOnEdge?: { top: boolean; bottom: boolean; left: boolean; right: boolean };
 } & Pick<FlexboxSystemProps, 'flexBasis' | 'flexGrow' | 'flexShrink'> &
   Pick<SizingSystemProps, 'minWidth' | 'width'> &
   Pick<TextProps, 'lineLimit' | 'overflowWrap' | 'whiteSpace' | 'wordBreak'>;

--- a/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCell.tsx
+++ b/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCell.tsx
@@ -36,11 +36,20 @@ export const TableHeaderCell = withTableHeaderCellVariation(
     alignHorizontal = 'center',
     alignVertical = 'center',
     sortable,
+    selectable,
     sortDirection = 'none',
     onSort,
+    onPressIn,
+    onPressOut,
+    onHoverIn,
     width,
   }) => {
     const handleSortButtonClick = () => {
+      // 선택 가능한 경우 선택 액션이 우선한다. 정렬은 정렬 버튼으로
+      if (selectable) {
+        return;
+      }
+
       const nextSortDirection = getNextSortDirection(sortDirection);
 
       onSort?.(nextSortDirection);
@@ -56,6 +65,9 @@ export const TableHeaderCell = withTableHeaderCellVariation(
         width={width}
         disabled={!sortable}
         onClick={handleSortButtonClick}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
+        onHoverIn={onHoverIn}
         cursor={sortable ? 'pointer' : 'default'}
         borderBottomColor="outline1"
         borderBottomWidth={1}

--- a/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCell.tsx
+++ b/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCell.tsx
@@ -42,6 +42,8 @@ export const TableHeaderCell = withTableHeaderCellVariation(
     onPressIn,
     onPressOut,
     onHoverIn,
+    selected,
+    selectedOnEdge,
     width,
   }) => {
     const handleSortButtonClick = () => {
@@ -73,6 +75,23 @@ export const TableHeaderCell = withTableHeaderCellVariation(
         borderBottomWidth={1}
         borderBottomStyle="solid"
       >
+        {selected && (
+          <Box
+            position="absolute"
+            top={0}
+            left={0}
+            bottom={0}
+            right={0}
+            borderWidth={1}
+            borderStyle="solid"
+            borderColor="outlineInformative"
+            backgroundColor="informativeContainer"
+            borderLeftWidth={selectedOnEdge?.left ? 1 : 0}
+            borderRightWidth={selectedOnEdge?.right ? 1 : 0}
+            borderTopWidth={1}
+            borderBottomWidth={0}
+          />
+        )}
         <VStack height="100%" alignVertical={alignVertical}>
           <HStack width="100%" alignVertical="center" alignHorizontal={alignHorizontal}>
             {renderCell ? (

--- a/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCell.tsx
+++ b/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCell.tsx
@@ -36,7 +36,7 @@ export const TableHeaderCell = withTableHeaderCellVariation(
     alignHorizontal = 'center',
     alignVertical = 'center',
     sortable,
-    selectable,
+    multiCellSelectable,
     sortDirection = 'none',
     onSort,
     onPressIn,
@@ -47,11 +47,6 @@ export const TableHeaderCell = withTableHeaderCellVariation(
     width,
   }) => {
     const handleSortButtonClick = () => {
-      // 선택 가능한 경우 선택 액션이 우선한다. 정렬은 정렬 버튼으로
-      if (selectable) {
-        return;
-      }
-
       const nextSortDirection = getNextSortDirection(sortDirection);
 
       onSort?.(nextSortDirection);
@@ -66,7 +61,7 @@ export const TableHeaderCell = withTableHeaderCellVariation(
         px={16}
         width={width}
         disabled={!sortable}
-        onClick={handleSortButtonClick}
+        onClick={!multiCellSelectable ? handleSortButtonClick : () => {}}
         onPressIn={onPressIn}
         onPressOut={onPressOut}
         onHoverIn={onHoverIn}
@@ -120,9 +115,9 @@ export const TableHeaderCell = withTableHeaderCellVariation(
               </>
             )}
             {sortable && (
-              <Box ml={4}>
+              <PressableBox ml={4} onClick={handleSortButtonClick}>
                 <TableSortIcon sortDirection={sortDirection} />
-              </Box>
+              </PressableBox>
             )}
           </HStack>
         </VStack>

--- a/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCellProps.ts
+++ b/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCellProps.ts
@@ -13,8 +13,12 @@ export type TableHeaderCellProps = {
   title?: TextChildren;
   description?: ReactElementChild | string;
   sortable?: boolean;
+  selectable?: boolean;
   sortDirection?: SortDirection;
   onSort?: (sortDirection: SortDirection) => void;
+  onPressIn?: () => void;
+  onPressOut?: () => void;
+  onHoverIn?: () => void;
   renderCell?: () => ReactElementChildren;
   alignVertical?: 'center' | 'end' | 'start';
   alignHorizontal?: 'center' | 'end' | 'start';

--- a/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCellProps.ts
+++ b/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCellProps.ts
@@ -19,6 +19,8 @@ export type TableHeaderCellProps = {
   onPressIn?: () => void;
   onPressOut?: () => void;
   onHoverIn?: () => void;
+  selected?: boolean;
+  selectedOnEdge?: { left: boolean; right: boolean };
   renderCell?: () => ReactElementChildren;
   alignVertical?: 'center' | 'end' | 'start';
   alignHorizontal?: 'center' | 'end' | 'start';

--- a/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCellProps.ts
+++ b/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCellProps.ts
@@ -14,6 +14,7 @@ export type TableHeaderCellProps = {
   description?: ReactElementChild | string;
   sortable?: boolean;
   selectable?: boolean;
+  multiCellSelectable?: boolean;
   sortDirection?: SortDirection;
   onSort?: (sortDirection: SortDirection) => void;
   onPressIn?: () => void;

--- a/packages/vibrant-components/src/lib/Table/TableProps.ts
+++ b/packages/vibrant-components/src/lib/Table/TableProps.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/naming-convention */
 import type { ComponentType, ReactElement } from 'react';
 import type { ReactElementChild, TextChildren } from '@vibrant-ui/core';

--- a/packages/vibrant-components/src/lib/Table/TableProps.ts
+++ b/packages/vibrant-components/src/lib/Table/TableProps.ts
@@ -13,11 +13,15 @@ export type UseTableResult<Data extends Record<string, any>, RowKey extends keyo
 
 export type TableSortBy<Data> = { dataKey?: keyof Data; direction: SortDirection };
 
+type TableCellRangeElement = { rowIdx: number; colIdx: number };
+export type TableCellRange = { cursor: TableCellRangeElement; anchor: TableCellRangeElement };
+
 export type TableProps<Data extends Record<string, any>, RowKey extends keyof Data> = {
   data: Data[];
   rowKey: RowKey;
   loading?: boolean;
   selectable?: boolean;
+  multiCellSelectable?: boolean;
   selectButtons?: { text: string; onClick: (selectedRows: Data[]) => void }[];
   onSelectionChange?: (selectedRowKeys: Data[RowKey][]) => void;
   renderExpanded?: (row: Data) => ReactElementChild;

--- a/packages/vibrant-core/src/lib/PressableBox/PressableBox.tsx
+++ b/packages/vibrant-core/src/lib/PressableBox/PressableBox.tsx
@@ -37,7 +37,11 @@ export const PressableBox = withPressableBoxVariation(
       onMouseLeave={() => onHoverOut?.()}
       onFocus={() => onFocusIn?.()}
       onBlur={() => onFocusOut?.()}
-      onMouseDown={() => onPressIn?.()}
+      onMouseDown={(event: { stopPropagation: () => void }) => {
+        event.stopPropagation();
+
+        onPressIn?.();
+      }}
       onMouseUp={() => {
         onPressOut?.();
 


### PR DESCRIPTION
1. 테이블에서 여러 셀을 선택 후, 복사할 수 있습니다.
2. tab 문자로 분리된 데이터 형식으로 복사됩니다.
3. shift 클릭으로 셀을 재선택할 수 있습니다.

<img width="828" alt="image" src="https://github.com/user-attachments/assets/8c143f57-6ae7-499d-81e7-b360512d476f" />
