### PR TITLE
fix(vibrant-components): fix table sort and selection error

### DIFF
--- a/packages/vibrant-components/src/lib/Table/Table.stories.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.stories.tsx
@@ -145,9 +145,7 @@ export const SelectableInteractiveTable: FC<ComponentProps<typeof Table> & { loc
   };
 
   const deleteRow = (data: Data) => () => {
-    const corresRowKey = data[props.rowKey as keyof Data];
-
-    setData(prev => prev.filter(row => row[props.rowKey as keyof Data] !== corresRowKey));
+    setData(prev => prev.filter(row => row !== data));
   };
 
   return (

--- a/packages/vibrant-components/src/lib/Table/Table.stories.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.stories.tsx
@@ -266,6 +266,7 @@ export const MultiCellSelectable: ComponentStory<typeof Table> = props => (
           onCopy: action('onDataCellCopy'),
         }}
         sortable={true}
+        sortDirection="asc"
       />
       <Table.Column<Data> key="fat" dataKey="fat" title="fat" description="abc" />
       <Table.Column<Data>
@@ -276,6 +277,7 @@ export const MultiCellSelectable: ComponentStory<typeof Table> = props => (
           onClick: action('onDateCellClick'),
           onCopy: action('onDataCellCopy'),
         }}
+        sortable={true}
       />
       <Table.Column<Data>
         key="protein"

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -4,7 +4,7 @@
 import type { ReactElement } from 'react';
 import { Children, isValidElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Image, ScrollBox, isNative, useConfig } from '@vibrant-ui/core';
-import { isDefined, useControllableState } from '@vibrant-ui/utils';
+import { isDefined } from '@vibrant-ui/utils';
 import { Body } from '../Body';
 import { GhostButton } from '../GhostButton';
 import { HStack } from '../HStack';
@@ -154,15 +154,52 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
     onSort?.(sortBy);
   };
 
-  const [selectedRowKeys, setSelectedRowKeys] = useControllableState<Set<Data[RowKey]>>({
-    defaultValue: new Set<Data[RowKey]>(),
-    onValueChange: (value: Set<Data[RowKey]>) => onSelectionChange?.([...value]),
-  });
+  const [selectedRows, setSelectedRows] = useState(new Set<Data>());
 
+  // 기존 onSelectionChange 동작을 보장하기 위해 rowKey로 호출할 수 있도록 변환
+  const mapRowsToRowKeys = useCallback((rows: Set<Data>) => [...Array(...rows).map(row => row[rowKey])], [rowKey]);
+
+  const handleSetSelectedRows = useCallback(
+    (value: Set<Data>) => {
+      setSelectedRows(value);
+      onSelectionChange?.(mapRowsToRowKeys(value));
+    },
+    [mapRowsToRowKeys, onSelectionChange]
+  );
+
+  // 데이터 변경 시에만 selectedRows 변경 및 onSelectionChange 호출하기 위해 사용
+  const prevData = useRef(data);
+
+  // data가 변경되면 data에 존재하지 않는 row를 selectedRows에서 제거
   useEffect(() => {
-    setSelectedRowKeys(new Set(data.filter(row => selectedRowKeys.has(row[rowKey])).map(row => row[rowKey])));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, rowKey]);
+    if (prevData.current === data) {
+      return;
+    }
+
+    const dataSet = new Set(data);
+    // prevData에서 data에 존재하는 row를 제거하고 남은 row가 제거 대상
+    const toBeRemovedRows = new Set(prevData.current.filter(row => !dataSet.has(row)));
+
+    if (toBeRemovedRows.size > 0) {
+      setSelectedRows(prev => {
+        const newSet = new Set(prev);
+        const sizeBeforeRemove = newSet.size;
+
+        toBeRemovedRows.forEach(row => newSet.delete(row));
+
+        // 선택된 상태에서 제거된 row가 있을 때만 onSelectionChange 호출하고 상태를 변경한다
+        if (sizeBeforeRemove > newSet.size) {
+          onSelectionChange?.(mapRowsToRowKeys(newSet));
+
+          return newSet;
+        }
+
+        return prev;
+      });
+    }
+
+    prevData.current = data;
+  }, [data, mapRowsToRowKeys, onSelectionChange]);
 
   const [selectedCellKey, setSelectedCellKey] = useState<string>();
   const isCellClickEnabled = columns?.some(column => isDefined(column.onDataCell));
@@ -252,29 +289,23 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
     navigator?.clipboard.writeText(clipboardText);
   }, [columns, data, selectedRange]);
 
-  const handleToggleCheckbox = (key: Data[RowKey]) => {
-    const newSelectedRowKeys = new Set(selectedRowKeys);
+  const handleToggleCheckbox = (key: Data) => {
+    const newSelectedRows = new Set(selectedRows);
 
-    if (newSelectedRowKeys.has(key)) {
-      newSelectedRowKeys.delete(key);
+    if (newSelectedRows.has(key)) {
+      newSelectedRows.delete(key);
     } else {
-      newSelectedRowKeys.add(key);
+      newSelectedRows.add(key);
     }
 
-    setSelectedRowKeys(newSelectedRowKeys);
+    handleSetSelectedRows(newSelectedRows);
   };
 
   const handleToggleAllCheckbox = ({ value }: { value: boolean }) => {
     if (value) {
-      const allRowKeys = new Set<Data[RowKey]>(
-        data
-          .filter(row => (isDefined(disabledRowKeys) ? !disabledRowKeys.includes(row[rowKey]) : true))
-          .map(row => row[rowKey])
-      );
-
-      setSelectedRowKeys(allRowKeys);
+      handleSetSelectedRows(new Set(data.filter(row => !disabledRowKeys?.includes(row[rowKey]))));
     } else {
-      setSelectedRowKeys(new Set());
+      handleSetSelectedRows(new Set());
     }
   };
 
@@ -307,7 +338,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
           <TableRow
             header={true}
             selectable={selectable}
-            selected={selectedRowKeys.size !== 0}
+            selected={selectedRows.size !== 0}
             expanded={!loading && data.length === 0}
             renderExpanded={() => (
               <VStack alignHorizontal="center" mt={32} mb={64}>
@@ -315,12 +346,12 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                 <Body level={1}>{emptyText}</Body>
               </VStack>
             )}
-            overlaid={selectable && selectedRowKeys.size > 0}
+            overlaid={selectable && selectedRows.size > 0}
             renderOverlay={() => (
               <HStack alignVertical="center" height="100%" spacing={12}>
-                {selectedRowKeys.size > 0 ? (
+                {selectedRows.size > 0 ? (
                   <Body level={2} weight="medium">
-                    {tableTranslation.numberOfSelected.replace('{count}', selectedRowKeys.size.toString())}
+                    {tableTranslation.numberOfSelected.replace('{count}', selectedRows.size.toString())}
                   </Body>
                 ) : null}
                 <HStack alignVertical="center" height="100%" spacing={12}>
@@ -329,7 +360,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                       key={text}
                       size="md"
                       color="onViewInformative"
-                      onClick={() => onClick(data.filter(row => selectedRowKeys.has(row[rowKey])))}
+                      onClick={() => onClick(data.filter(row => selectedRows.has(row[rowKey])))}
                     >
                       {text}
                     </GhostButton>
@@ -337,7 +368,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                 </HStack>
               </HStack>
             )}
-            indeterminate={selectedRowKeys.size !== data.length}
+            indeterminate={selectedRows.size !== data.length}
             onSelectionChange={handleToggleAllCheckbox}
             disabled={loading}
           >
@@ -410,10 +441,10 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
           {!loading
             ? data.map((row, rowIdx) => (
                 <TableRow
-                  key={row[rowKey]}
+                  key={rowKey ? row[rowKey] : rowIdx}
                   selectable={selectable}
-                  selected={selectedRowKeys.has(row[rowKey])}
-                  onSelectionChange={() => handleToggleCheckbox(row[rowKey])}
+                  selected={selectedRows.has(row)}
+                  onSelectionChange={() => handleToggleCheckbox(row)}
                   expandable={isDefined(renderExpanded)}
                   renderExpanded={() => (
                     <Paper backgroundColor="surface1" p={16}>

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -127,20 +127,26 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
     [children]
   );
 
-  const [sortBy, setSortBy] = useState<TableSortBy<Data>>({
-    direction: 'none',
-  });
+  const [sortBy, setSortBy] = useState<TableSortBy<Data>>();
 
-  useEffect(() => {
-    const defaultSort = columns.find(column => column.sortDirection && column.sortDirection !== 'none');
+  const defaultSortColumn = useMemo(
+    () => columns.find(column => column.sortDirection && column.sortDirection !== 'none'),
+    [columns]
+  );
 
-    if (defaultSort && defaultSort.dataKey !== sortBy.dataKey) {
-      setSortBy({
-        dataKey: defaultSort.dataKey,
-        direction: defaultSort.sortDirection ?? 'none',
-      });
-    }
-  }, [columns, sortBy.dataKey]);
+  const defaultSortBy = useMemo(
+    () => ({
+      dataKey: defaultSortColumn?.dataKey,
+      direction: defaultSortColumn?.sortDirection ?? 'none',
+    }),
+    [defaultSortColumn]
+  );
+
+  // sortBy가 존재하고 columns에 해당 dataKey가 있을 때만 sortBy 적용
+  const finalSortBy = useMemo(
+    () => (sortBy && columns.some(column => column.dataKey === sortBy.dataKey) ? sortBy : defaultSortBy),
+    [columns, defaultSortBy, sortBy]
+  );
 
   const handleChangeSort = (sortBy: TableSortBy<Data>) => {
     setSortBy(sortBy);
@@ -364,7 +370,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                   whiteSpace={whiteSpace?.header}
                   overflowWrap={overflowWrap?.header}
                   renderCell={renderHeader}
-                  sortDirection={sortBy.dataKey === dataKey ? sortBy.direction : 'none'}
+                  sortDirection={finalSortBy.dataKey === dataKey ? finalSortBy.direction : 'none'}
                   onSort={(sortDirection: SortDirection) => handleChangeSort({ dataKey, direction: sortDirection })}
                   multiCellSelectable={multiCellSelectable}
                   onPressIn={() => {

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -142,7 +142,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
     [defaultSortColumn]
   );
 
-  // sortBy가 존재하고 columns에 해당 dataKey가 있을 때만 sortBy 적용
+  // sortBy가 존재하고 columns에 해당 dataKey가 있을 때만 sortBy 적용 (columns 변경에 대비)
   const finalSortBy = useMemo(
     () => (sortBy && columns.some(column => column.dataKey === sortBy.dataKey) ? sortBy : defaultSortBy),
     [columns, defaultSortBy, sortBy]


### PR DESCRIPTION
1. Default sort, sortDirection 이 설정되었을 때, 다른 sort 버튼을 누르면 Default sort 로 복구되는 이슈 수정
2. 선택 사항의 변화가 없는데도 콜백 함수 호출 및 상태 변경이 되는 이슈 수정
3. row 선택 구분을 rowKey가 아닌 row 객체로 구분

영상 1.

https://github.com/user-attachments/assets/b1ef6895-40b1-44da-b658-223136ac00be

영상 2.

https://github.com/user-attachments/assets/b05d84e6-6636-4305-a13a-e1a2d6963184


