### PR TITLE
fix(vibrant-components): table and virtualized-table selection copy

### DIFF
--- a/packages/vibrant-components-web/src/lib/VirtualizedTable/VirtualizedTable.stories.tsx
+++ b/packages/vibrant-components-web/src/lib/VirtualizedTable/VirtualizedTable.stories.tsx
@@ -64,6 +64,7 @@ export default {
     onRow: {
       onClick: action('onRow'),
     },
+    onCopy: action('onCopy'),
     disabledRowKeys: ['Cupcake'],
     emptyImage: 'https://cdn.class101.net/images/a097865b-683e-4386-a6a3-1fa27d1463d0',
     emptyText: 'No Data',

--- a/packages/vibrant-components-web/src/lib/VirtualizedTable/VirtualizedTable.tsx
+++ b/packages/vibrant-components-web/src/lib/VirtualizedTable/VirtualizedTable.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-lines */
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Children, isValidElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/packages/vibrant-components-web/src/lib/VirtualizedTable/VirtualizedTable.tsx
+++ b/packages/vibrant-components-web/src/lib/VirtualizedTable/VirtualizedTable.tsx
@@ -164,6 +164,9 @@ export const VirtualizedTable = <Data extends Record<string, any>, RowKey extend
     }
 
     isSelectingRange.current = false;
+    // TODO: workaround for react-virtuoso, 개선 필요
+    // render 후에 focus 가  body로 가는 문제
+    setTimeout(() => tableRef.current?.focus(), 0);
   }, [multiCellSelectable]);
 
   const handleToggleAllCheckbox = ({ value }: { value: boolean }) => {

--- a/packages/vibrant-components-web/src/lib/VirtualizedTable/VirtualizedTableProps.ts
+++ b/packages/vibrant-components-web/src/lib/VirtualizedTable/VirtualizedTableProps.ts
@@ -1,5 +1,28 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { TableProps } from '@vibrant-ui/components';
 
-export type VirtualizedTableProps<Data extends Record<string, any>, RowKey extends keyof Data> = {
+type BaseProps<Data extends Record<string, any>, RowKey extends keyof Data> = {
   height?: number;
 } & TableProps<Data, RowKey>;
+
+type OnlyMultiSelect<Data extends Record<string, any>, RowKey extends keyof Data> = {
+  multiCellSelectable: boolean;
+  onRow?: never;
+} & BaseProps<Data, RowKey>;
+
+type OnlyOnRow<Data extends Record<string, any>, RowKey extends keyof Data> = {
+  onRow: {
+    onClick: (row: Data) => void;
+  };
+  multiCellSelectable?: never;
+} & BaseProps<Data, RowKey>;
+
+type Neither<Data extends Record<string, any>, RowKey extends keyof Data> = {
+  multiCellSelectable?: never;
+  onRow?: never;
+} & BaseProps<Data, RowKey>;
+
+export type VirtualizedTableProps<Data extends Record<string, any>, RowKey extends keyof Data> =
+  | Neither<Data, RowKey>
+  | OnlyMultiSelect<Data, RowKey>
+  | OnlyOnRow<Data, RowKey>;

--- a/packages/vibrant-components/src/lib/Table/Table.stories.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.stories.tsx
@@ -55,6 +55,7 @@ export default {
     onRow: {
       onClick: action('onRow'),
     },
+    onCopy: action('onCopy'),
     disabledRowKeys: ['Cupcake'],
     emptyImage: 'https://cdn.class101.net/images/a097865b-683e-4386-a6a3-1fa27d1463d0',
     emptyText: 'No Data',

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -291,6 +291,14 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
     navigator?.clipboard.writeText(clipboardText);
   }, [columns, data, onCopy, selectedRange]);
 
+  const handlePressOut = useCallback(() => {
+    if (!multiCellSelectable) {
+      return;
+    }
+
+    isSelectingRange.current = false;
+  }, [multiCellSelectable]);
+
   const handleToggleCheckbox = (key: Data) => {
     const newSelectedRows = new Set(selectedRows);
 
@@ -407,6 +415,10 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                   onSort={(sortDirection: SortDirection) => handleChangeSort({ dataKey, direction: sortDirection })}
                   multiCellSelectable={multiCellSelectable}
                   onPressIn={() => {
+                    if (!multiCellSelectable) {
+                      return;
+                    }
+
                     setSelectingRangeFromCell(false);
                     isSelectingRange.current = true;
                     setSelectedRange(prev => ({
@@ -417,11 +429,14 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                       cursor: { rowIdx: data.length - 1, colIdx },
                     }));
                   }}
-                  onPressOut={() => {
-                    isSelectingRange.current = false;
-                  }}
+                  onPressOut={handlePressOut}
                   onHoverIn={() => {
-                    if (!isSelectingRange.current) {
+                    if (!isSelectingRange.current || !multiCellSelectable) {
+                      return;
+                    }
+
+                    // cursor 위치가 같으면 range 선택하지 않음
+                    if (selectedRange?.cursor?.colIdx === colIdx) {
                       return;
                     }
 
@@ -487,6 +502,10 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                           }
                         }}
                         onPressIn={() => {
+                          if (!multiCellSelectable) {
+                            return;
+                          }
+
                           setSelectingRangeFromCell(true);
                           isSelectingRange.current = true;
                           setSelectedRange(prev => ({
@@ -494,11 +513,14 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
                             cursor: { rowIdx, colIdx },
                           }));
                         }}
-                        onPressOut={() => {
-                          isSelectingRange.current = false;
-                        }}
+                        onPressOut={handlePressOut}
                         onHoverIn={() => {
-                          if (!isSelectingRange.current) {
+                          if (!isSelectingRange.current || !multiCellSelectable) {
+                            return;
+                          }
+
+                          // cursor 위치가 같으면 range 선택하지 않음
+                          if (selectedRange?.cursor?.rowIdx === rowIdx && selectedRange?.cursor?.colIdx === colIdx) {
                             return;
                           }
 

--- a/packages/vibrant-components/src/lib/Table/Table.tsx
+++ b/packages/vibrant-components/src/lib/Table/Table.tsx
@@ -109,6 +109,7 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
   renderExpanded,
   onRow,
   onSort,
+  onCopy,
   emptyText,
   emptyImage,
   children,
@@ -286,8 +287,9 @@ export const Table = <Data extends Record<string, any>, RowKey extends keyof Dat
 
     const clipboardText = selectedCells.join('\n');
 
+    onCopy?.(clipboardText);
     navigator?.clipboard.writeText(clipboardText);
-  }, [columns, data, selectedRange]);
+  }, [columns, data, onCopy, selectedRange]);
 
   const handleToggleCheckbox = (key: Data) => {
     const newSelectedRows = new Set(selectedRows);

--- a/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCell.tsx
+++ b/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCell.tsx
@@ -60,6 +60,7 @@ export const TableHeaderCell = withTableHeaderCellVariation(
         py={12}
         px={16}
         width={width}
+        // 멀티셀 선택 기능을 우선하고, 이 경우 소트는 SortIcon을 클릭해야만 동작
         onClick={!multiCellSelectable ? handleSortButtonClick : () => {}}
         onPressIn={onPressIn}
         onPressOut={onPressOut}

--- a/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCell.tsx
+++ b/packages/vibrant-components/src/lib/Table/TableHeaderCell/TableHeaderCell.tsx
@@ -60,7 +60,6 @@ export const TableHeaderCell = withTableHeaderCellVariation(
         py={12}
         px={16}
         width={width}
-        disabled={!sortable}
         onClick={!multiCellSelectable ? handleSortButtonClick : () => {}}
         onPressIn={onPressIn}
         onPressOut={onPressOut}

--- a/packages/vibrant-components/src/lib/Table/TableProps.ts
+++ b/packages/vibrant-components/src/lib/Table/TableProps.ts
@@ -30,6 +30,7 @@ export type TableProps<Data extends Record<string, any>, RowKey extends keyof Da
     onClick: (row: Data) => void;
   };
   onSort?: (sortBy: TableSortBy<Data>) => void;
+  onCopy?: (rows: string) => void;
   emptyText?: TextChildren;
   emptyImage?: string;
   disabledRowKeys?: Data[RowKey][];


### PR DESCRIPTION
- `TableHeaderCell`이 `sortable` 아닌 경우에도 활성화 되도록 변경
- Virtualized Table 에서 리렌더링으로 인해 복사가 되지 않던 문제 해결
- `onCopy` 이벤트 추가 및 Storybook 반영