### PR TITLE
fix: 고스트 버튼의 배경색을 transparent로 고정한다

### DIFF
--- a/packages/vibrant-components/src/lib/GhostButton/GhostButton.tsx
+++ b/packages/vibrant-components/src/lib/GhostButton/GhostButton.tsx
@@ -31,6 +31,7 @@ export const GhostButton = withGhostButtonVariation(
       data-testid={testId}
       flexDirection="row"
       alignItems="center"
+      backgroundColor="transparent"
     >
       {IconComponent && <IconComponent size={iconSize} fill={color} />}
       <Text


### PR DESCRIPTION
고스트 버튼을 감싸고 있는 부모의 배경색이 투명도를 갖는 경우
고스트 버튼도 부모의 배경색을 동일하게 상속받아 색상이 진하게 노출되는 문제가 있어
**고스트 버튼의 배경색을 transparent로 고정했습니다**

before
<img width="307" alt="스크린샷 2025-04-24 오후 12 18 58" src="https://github.com/user-attachments/assets/7b3ee6e4-6b97-4f54-af93-7cb16b054a51" />


after
<img width="274" alt="스크린샷 2025-04-24 오후 12 19 15" src="https://github.com/user-attachments/assets/74fc4d56-2960-4372-b28e-93bde56f6c3c" />

