### PR TITLE
feat(ModalBottomSheet): add xl size variant

### DIFF
--- a/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheetProps.ts
+++ b/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheetProps.ts
@@ -13,7 +13,7 @@ export type ModalBottomSheetProps = Either<
 > & {
   title?: string;
   subtitle?: string;
-  size?: 'full' | 'lg' | 'md';
+  size?: 'full' | 'lg' | 'md' | 'xl';
   testId?: string;
   renderContents?: (_: { close: () => void }) => ReactElementChild;
   onClose?: () => void;
@@ -76,6 +76,9 @@ export const withModalBottomSheetVariation = withVariation<ModalBottomSheetProps
       },
       lg: {
         desktopModalWidth: 760,
+      },
+      xl: {
+        desktopModalWidth: 1132,
       },
       full: {
         desktopModalWidth: '100%',


### PR DESCRIPTION
- Added a new `xl` size variant to the `ModalBottomSheet` component.
- `xl` size sets the `desktopModalWidth` to `1132px`.
- Useful for layouts that require a wider modal on desktop.

e.g.
-xl
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/d1449911-4db9-4e9e-a27a-b42cf6e5031f" />
-lg
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/0295ef39-308a-4a58-a8b9-34b8d7cf7b89" />
