### PR TITLE
fix(Skeleton): 배경색을 overlay로 한다

### DIFF
--- a/packages/vibrant-components/src/lib/Skeleton/Skeleton.spec.tsx
+++ b/packages/vibrant-components/src/lib/Skeleton/Skeleton.spec.tsx
@@ -10,9 +10,7 @@ describe('<Skeleton />', () => {
 
   describe('when basic Skeleton is rendered', () => {
     beforeEach(async () => {
-      renderer = render(
-        <Skeleton data-testid="skeleton" width={100} height={50} rounded="md" />
-      );
+      renderer = render(<Skeleton data-testid="skeleton" width={100} height={50} rounded="md" />);
 
       element = await renderer.findByTestId('skeleton');
     });
@@ -30,14 +28,13 @@ describe('<Skeleton />', () => {
 
   describe('when Skeleton.Text is rendered', () => {
     beforeEach(async () => {
-      renderer = render(
-        <Skeleton.Text data-testid="skeleton-text" lines={3} typography="body1" />
-      );
+      renderer = render(<Skeleton.Text data-testid="skeleton-text" lines={3} typography="body1" />);
     });
 
     it('should render correct number of lines', async () => {
       const lines = await renderer.findAllByRole('generic');
       // VStack + (3 lines * 2 components per line)
+      
       expect(lines.length).toBeGreaterThan(3);
     });
 
@@ -48,9 +45,7 @@ describe('<Skeleton />', () => {
 
   describe('when Skeleton.Avatar is rendered', () => {
     beforeEach(async () => {
-      renderer = render(
-        <Skeleton.Avatar data-testid="skeleton-avatar" size="md" />
-      );
+      renderer = render(<Skeleton.Avatar data-testid="skeleton-avatar" size="md" />);
     });
 
     it('match snapshot', () => {
@@ -60,9 +55,7 @@ describe('<Skeleton />', () => {
 
   describe('when Skeleton.Button is rendered', () => {
     beforeEach(async () => {
-      renderer = render(
-        <Skeleton.Button data-testid="skeleton-button" size="md" />
-      );
+      renderer = render(<Skeleton.Button data-testid="skeleton-button" size="md" />);
     });
 
     it('match snapshot', () => {
@@ -72,13 +65,11 @@ describe('<Skeleton />', () => {
 
   describe('when Skeleton.Image is rendered', () => {
     beforeEach(async () => {
-      renderer = render(
-        <Skeleton.Image data-testid="skeleton-image" width={200} ratio={1.5} />
-      );
+      renderer = render(<Skeleton.Image data-testid="skeleton-image" width={200} ratio={1.5} />);
     });
 
     it('match snapshot', () => {
       expect(renderer.container).toMatchSnapshot();
     });
   });
-}); 
+});

--- a/packages/vibrant-components/src/lib/Skeleton/Skeleton.spec.tsx
+++ b/packages/vibrant-components/src/lib/Skeleton/Skeleton.spec.tsx
@@ -1,0 +1,84 @@
+import { baseTheme } from '@vibrant-ui/theme';
+import type { ReactRenderer } from '@vibrant-ui/utils/testing-web';
+import { createReactRenderer } from '@vibrant-ui/utils/testing-web';
+import { Skeleton } from './Skeleton';
+
+describe('<Skeleton />', () => {
+  const { render } = createReactRenderer();
+  let renderer: ReactRenderer;
+  let element: HTMLElement;
+
+  describe('when basic Skeleton is rendered', () => {
+    beforeEach(async () => {
+      renderer = render(
+        <Skeleton data-testid="skeleton" width={100} height={50} rounded="md" />
+      );
+
+      element = await renderer.findByTestId('skeleton');
+    });
+
+    it('should have correct dimensions and styles', () => {
+      expect(element).toHaveStyleRule('width', '100px');
+      expect(element).toHaveStyleRule('height', '50px');
+      expect(element).toHaveStyleRule('background-color', baseTheme.colors.light.overlay);
+    });
+
+    it('match snapshot', () => {
+      expect(renderer.container).toMatchSnapshot();
+    });
+  });
+
+  describe('when Skeleton.Text is rendered', () => {
+    beforeEach(async () => {
+      renderer = render(
+        <Skeleton.Text data-testid="skeleton-text" lines={3} typography="body1" />
+      );
+    });
+
+    it('should render correct number of lines', async () => {
+      const lines = await renderer.findAllByRole('generic');
+      // VStack + (3 lines * 2 components per line)
+      expect(lines.length).toBeGreaterThan(3);
+    });
+
+    it('match snapshot', () => {
+      expect(renderer.container).toMatchSnapshot();
+    });
+  });
+
+  describe('when Skeleton.Avatar is rendered', () => {
+    beforeEach(async () => {
+      renderer = render(
+        <Skeleton.Avatar data-testid="skeleton-avatar" size="md" />
+      );
+    });
+
+    it('match snapshot', () => {
+      expect(renderer.container).toMatchSnapshot();
+    });
+  });
+
+  describe('when Skeleton.Button is rendered', () => {
+    beforeEach(async () => {
+      renderer = render(
+        <Skeleton.Button data-testid="skeleton-button" size="md" />
+      );
+    });
+
+    it('match snapshot', () => {
+      expect(renderer.container).toMatchSnapshot();
+    });
+  });
+
+  describe('when Skeleton.Image is rendered', () => {
+    beforeEach(async () => {
+      renderer = render(
+        <Skeleton.Image data-testid="skeleton-image" width={200} ratio={1.5} />
+      );
+    });
+
+    it('match snapshot', () => {
+      expect(renderer.container).toMatchSnapshot();
+    });
+  });
+}); 

--- a/packages/vibrant-components/src/lib/Skeleton/Skeleton.spec.tsx
+++ b/packages/vibrant-components/src/lib/Skeleton/Skeleton.spec.tsx
@@ -34,7 +34,7 @@ describe('<Skeleton />', () => {
     it('should render correct number of lines', async () => {
       const lines = await renderer.findAllByRole('generic');
       // VStack + (3 lines * 2 components per line)
-      
+
       expect(lines.length).toBeGreaterThan(3);
     });
 

--- a/packages/vibrant-components/src/lib/Skeleton/Skeleton.tsx
+++ b/packages/vibrant-components/src/lib/Skeleton/Skeleton.tsx
@@ -16,7 +16,7 @@ import type { SkeletonTextProps } from './SkeletonText';
 import { SkeletonText } from './SkeletonText';
 
 export const Skeleton = withSkeletonVariation(props => (
-  <Box backgroundColor="disable" {...props} />
+  <Box backgroundColor="overlay" {...props} />
 )) as ComponentWithRef<SkeletonProps> & {
   Image: ComponentWithRef<SkeletonImageProps>;
   Button: ComponentWithRef<SkeletonButtonProps>;

--- a/packages/vibrant-components/src/lib/Skeleton/__snapshots__/Skeleton.spec.tsx.snap
+++ b/packages/vibrant-components/src/lib/Skeleton/__snapshots__/Skeleton.spec.tsx.snap
@@ -1,0 +1,356 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Skeleton /> when Skeleton.Avatar is rendered match snapshot 1`] = `
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-sizing: border-box;
+  position: relative;
+  background-color: #0000001a;
+  border-radius: 10000px;
+  width: 30px;
+  height: 30px;
+}
+
+<div>
+  <div
+    class="emotion-0"
+  />
+</div>
+`;
+
+exports[`<Skeleton /> when Skeleton.Button is rendered match snapshot 1`] = `
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-sizing: border-box;
+  position: relative;
+  background-color: #0000001a;
+  border-radius: 4px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  width: 72px;
+}
+
+.emotion-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-sizing: border-box;
+  position: relative;
+  height: 18px;
+}
+
+<div>
+  <div
+    class="emotion-0"
+  >
+    <div
+      class="emotion-1"
+    />
+  </div>
+</div>
+`;
+
+exports[`<Skeleton /> when Skeleton.Image is rendered match snapshot 1`] = `
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-sizing: border-box;
+  position: relative;
+  width: 200px;
+}
+
+.emotion-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-sizing: border-box;
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-bottom: 66.66666666666666%;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-sizing: border-box;
+  position: relative;
+  background-color: #0000001a;
+  width: 100%;
+  height: 100%;
+  border-radius: 4px;
+}
+
+<div>
+  <div
+    class="emotion-0"
+    data-testid="ratio"
+  >
+    <div
+      class="emotion-1"
+    >
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+          data-testid="skeleton-image"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Skeleton /> when Skeleton.Text is rendered match snapshot 1`] = `
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-sizing: border-box;
+  position: relative;
+  width: 100%;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.emotion-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-sizing: border-box;
+  position: relative;
+  width: 100%;
+  height: 20px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-sizing: border-box;
+  position: relative;
+  background-color: #0000001a;
+  height: 16px;
+  border-radius: 4px;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-sizing: border-box;
+  position: relative;
+  width: 40%;
+  height: 20px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+<div>
+  <div
+    class="emotion-0"
+  >
+    <div
+      class="emotion-1"
+    >
+      <div
+        class="emotion-2"
+      />
+    </div>
+    <div
+      class="emotion-1"
+    >
+      <div
+        class="emotion-2"
+      />
+    </div>
+    <div
+      class="emotion-5"
+    >
+      <div
+        class="emotion-2"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Skeleton /> when basic Skeleton is rendered match snapshot 1`] = `
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-sizing: border-box;
+  position: relative;
+  background-color: #0000000d;
+  width: 100px;
+  height: 50px;
+  border-radius: 8px;
+}
+
+<div>
+  <div
+    class="emotion-0"
+    data-testid="skeleton"
+  />
+</div>
+`;


### PR DESCRIPTION
- Skeleton의 fill color 토큰을 disabled -> overlay로 변경합니다.
- test 파일도 추가하였습니다.

변경 전
![image](https://github.com/user-attachments/assets/34f460a9-34f8-46e0-a94c-ed9f8e787a6a)

변경 후
![image](https://github.com/user-attachments/assets/132fa547-3e46-4fce-a1b7-693d4fe01d9e)
