### PR TITLE
fix: filterChip props에서 순환 참조가 발생하는 문제를 해결한다

### DIFF
--- a/packages/vibrant-components/src/lib/FilterChip/FilterChipProps.ts
+++ b/packages/vibrant-components/src/lib/FilterChip/FilterChipProps.ts
@@ -48,7 +48,8 @@ export const withFilterChipVariation = withVariation<FilterChipProps>('FilterChi
         bodyLevel: 2,
         iconSize: 16,
         minHeight: 38,
-        p: 10,
+        px: 10,
+        py: 10,
         spacing: 4,
         rounded: 'xl',
       } as const;

--- a/packages/vibrant-components/src/lib/FilterChip/__snapshots__/FilterChip.spec.tsx.snap
+++ b/packages/vibrant-components/src/lib/FilterChip/__snapshots__/FilterChip.spec.tsx.snap
@@ -33,7 +33,10 @@ exports[`<FilterChip /> when href provided match snapshot 1`] = `
   -ms-flex-item-align: flex-start;
   align-self: flex-start;
   min-height: 38px;
-  padding: 10px;
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-top: 10px;
+  padding-bottom: 10px;
   border-radius: 16px;
   background-color: #00000008;
 }


### PR DESCRIPTION
before

<img width="1071" alt="스크린샷 2025-05-21 오후 12 51 51" src="https://github.com/user-attachments/assets/e7d9fe2a-c555-4cdf-84fa-84c35233306b" />

![스크린샷 2025-05-20 오후 4 38 22](https://github.com/user-attachments/assets/568f8d11-a895-4493-833f-75f2401a7b4a)



after

https://github.com/user-attachments/assets/6c9a79e2-ac79-4723-926d-57bf6a1b3dc9

