### PR TITLE
feat: TabView 컴포넌트에 swipe 사용 여부 기능 추가

### DIFF
--- a/packages/vibrant-components/src/lib/ViewPagerTabGroup/ViewPagerTabGroup.tsx
+++ b/packages/vibrant-components/src/lib/ViewPagerTabGroup/ViewPagerTabGroup.tsx
@@ -11,7 +11,7 @@ import type { ViewPagerTabGroupProps } from './ViewPagerTabGroupProps';
 import { withViewPagerTabGroupVariation } from './ViewPagerTabGroupProps';
 
 export const ViewPagerTabGroup = withViewPagerTabGroupVariation(
-  ({ children, tabId, testId, onTabChange, tabSpacing }) => (
+  ({ children, tabId, testId, onTabChange, tabSpacing, native_swipeEnabled = true }) => (
     <TabView
       tabId={tabId}
       testId={testId}
@@ -29,6 +29,7 @@ export const ViewPagerTabGroup = withViewPagerTabGroupVariation(
         </VStack>
       )}
       onTabChange={onTabChange}
+      native_swipeEnabled={native_swipeEnabled}
     >
       {children}
     </TabView>

--- a/packages/vibrant-components/src/lib/ViewPagerTabGroup/ViewPagerTabGroupProps.ts
+++ b/packages/vibrant-components/src/lib/ViewPagerTabGroup/ViewPagerTabGroupProps.ts
@@ -8,6 +8,7 @@ export type ViewPagerTabGroupProps = {
   tabId?: string;
   onTabChange?: () => void;
   testId?: string;
+  native_swipeEnabled?: boolean;
 };
 
 export const withViewPagerTabGroupVariation = withVariation<ViewPagerTabGroupProps>('ViewPagerTabGroup')();

--- a/packages/vibrant-core/src/lib/TabView/TabView.native.tsx
+++ b/packages/vibrant-core/src/lib/TabView/TabView.native.tsx
@@ -7,7 +7,7 @@ import type { TabViewItemProps } from '../TabViewItem';
 import { withTabViewVariation } from './TabViewProps';
 
 export const TabView = withTabViewVariation(
-  ({ children, tabId, onTabChange, renderTobBarContainer, renderTobBarItem }) => {
+  ({ children, tabId, onTabChange, renderTobBarContainer, renderTobBarItem, native_swipeEnabled = true }) => {
     const childrenElement = Children.toArray(children).filter(isValidElement<TabViewItemProps>);
     const [currentIndex, setCurrentIndex] = useState(
       Math.max(
@@ -75,6 +75,7 @@ export const TabView = withTabViewVariation(
         navigationState={{ index: currentIndex, routes }}
         renderScene={renderScene}
         onIndexChange={setCurrentIndex}
+        swipeEnabled={native_swipeEnabled}
       />
     );
   }

--- a/packages/vibrant-core/src/lib/TabView/TabViewProps.ts
+++ b/packages/vibrant-core/src/lib/TabView/TabViewProps.ts
@@ -10,6 +10,7 @@ type TabViewProps = {
   renderTobBarContainer: (props: ReactElementChildren) => ReactElement;
   onTabChange?: () => void;
   testId?: string;
+  native_swipeEnabled?: boolean;
 };
 
 export const withTabViewVariation = withVariation<TabViewProps>('TabView')();


### PR DESCRIPTION
TabView에서 swipe 기능을 제한하는 요구사항을 위해 swipeEnabled props을 추가했습니다.
네이티브에만 적용되며 [react-native-tab-view 문서](https://www.npmjs.com/package/react-native-tab-view/v/3.3.4#swipeenabled)를 참고하여 작업 했습니다.