### PR TITLE
feat: modalBottomSheet의 subtitle 색상 변경, 버튼 스펙을 변경한다

### DIFF
--- a/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.native.tsx
+++ b/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.native.tsx
@@ -340,12 +340,13 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
                     {isDefined(primaryButtonOptions) && isDefined(secondaryButtonOptions) && (
                       <VStack>
                         <Stack
-                          direction={buttonDirection}
                           px={[20, 32]}
                           mt={[20, 24]}
                           flexShrink={0}
                           width="100%"
                           spacing={8}
+                          direction={buttonDirection}
+                          reverse={buttonDirection === 'horizontal' ? true : false}
                         >
                           <ContainedButton
                             kind={primaryButtonOptions.kind ?? 'primary'}

--- a/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.native.tsx
+++ b/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.native.tsx
@@ -21,6 +21,7 @@ import { ContainedButton } from '../ContainedButton';
 import { GhostButton } from '../GhostButton';
 import { HStack } from '../HStack';
 import { IconButton } from '../IconButton';
+import { Stack } from '../Stack';
 import { Title } from '../Title';
 import { VStack } from '../VStack';
 import { withModalBottomSheetVariation } from './ModalBottomSheetProps';
@@ -45,6 +46,7 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
     transitionDuration = 300,
     native_swipeToCloseThreshold = 0.4,
     native_swipeToCloseVelocity = 200,
+    buttonDirection = 'vertical',
   }) => {
     const { getResponsiveValue } = useResponsiveValue();
     const { generateStyle } = useSafeArea();
@@ -202,6 +204,23 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
       [isOpen, renderOpener, setIsOpen]
     );
 
+    const subButton = useMemo(
+      () =>
+        subButtonOptions ? (
+          <Box alignSelf="center" mt={12}>
+            <GhostButton
+              size="md"
+              onClick={() => subButtonOptions.onClick?.({ close: closeModal })}
+              disabled={subButtonOptions.disabled}
+              IconComponent={subButtonOptions.IconComponent}
+            >
+              {subButtonOptions.text}
+            </GhostButton>
+          </Box>
+        ) : null,
+      [closeModal, subButtonOptions]
+    );
+
     return (
       <>
         {opener}
@@ -286,27 +305,48 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
                       </ScrollBox>
                     )}
 
-                    {isDefined(primaryButtonOptions) &&
-                      !isDefined(secondaryButtonOptions) &&
-                      !isDefined(subButtonOptions) && (
-                        <VStack px={[20, 32]} mt={[20, 24]} flexShrink={0}>
-                          <ContainedButton
-                            kind={primaryButtonOptions.kind ?? 'primary'}
-                            size="xl"
-                            onClick={() => primaryButtonOptions.onClick?.({ close: closeModal })}
-                            full={true}
-                            disabled={primaryButtonOptions.disabled}
-                            loading={primaryButtonOptions.loading}
-                            IconComponent={primaryButtonOptions.IconComponent}
-                          >
-                            {primaryButtonOptions.text}
-                          </ContainedButton>
-                        </VStack>
-                      )}
-                    {isDefined(primaryButtonOptions) &&
-                      isDefined(secondaryButtonOptions) &&
-                      !isDefined(subButtonOptions) && (
-                        <VStack px={[20, 32]} mt={[20, 24]} flexShrink={0} width="100%" spacing={8}>
+                    {isDefined(primaryButtonOptions) && !isDefined(secondaryButtonOptions) && (
+                      <VStack px={[20, 32]} mt={[20, 24]} flexShrink={0}>
+                        <ContainedButton
+                          kind={primaryButtonOptions.kind ?? 'primary'}
+                          size="xl"
+                          onClick={() => primaryButtonOptions.onClick?.({ close: closeModal })}
+                          full={true}
+                          disabled={primaryButtonOptions.disabled}
+                          loading={primaryButtonOptions.loading}
+                          IconComponent={primaryButtonOptions.IconComponent}
+                        >
+                          {primaryButtonOptions.text}
+                        </ContainedButton>
+                        {isDefined(subButtonOptions) && subButton}
+                      </VStack>
+                    )}
+                    {!isDefined(primaryButtonOptions) && isDefined(secondaryButtonOptions) && (
+                      <VStack px={[20, 32]} mt={[20, 24]} flexShrink={0}>
+                        <ContainedButton
+                          kind={secondaryButtonOptions.kind ?? 'tertiary'}
+                          size="xl"
+                          onClick={() => secondaryButtonOptions.onClick?.({ close: closeModal })}
+                          full={true}
+                          disabled={secondaryButtonOptions.disabled}
+                          loading={secondaryButtonOptions.loading}
+                          IconComponent={secondaryButtonOptions.IconComponent}
+                        >
+                          {secondaryButtonOptions.text}
+                        </ContainedButton>
+                        {isDefined(subButtonOptions) && subButton}
+                      </VStack>
+                    )}
+                    {isDefined(primaryButtonOptions) && isDefined(secondaryButtonOptions) && (
+                      <VStack>
+                        <Stack
+                          direction={buttonDirection}
+                          px={[20, 32]}
+                          mt={[20, 24]}
+                          flexShrink={0}
+                          width="100%"
+                          spacing={8}
+                        >
                           <ContainedButton
                             kind={primaryButtonOptions.kind ?? 'primary'}
                             size="xl"
@@ -329,35 +369,10 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
                           >
                             {secondaryButtonOptions.text}
                           </ContainedButton>
-                        </VStack>
-                      )}
-                    {isDefined(primaryButtonOptions) &&
-                      !isDefined(secondaryButtonOptions) &&
-                      isDefined(subButtonOptions) && (
-                        <VStack px={[20, 32]} mt={[20, 24]} flexShrink={0} width="100%" spacing={16}>
-                          <ContainedButton
-                            kind={primaryButtonOptions.kind ?? 'primary'}
-                            size="xl"
-                            onClick={() => primaryButtonOptions.onClick?.({ close: closeModal })}
-                            full={true}
-                            disabled={primaryButtonOptions.disabled}
-                            loading={primaryButtonOptions.loading}
-                            IconComponent={primaryButtonOptions.IconComponent}
-                          >
-                            {primaryButtonOptions.text}
-                          </ContainedButton>
-                          <Box alignSelf="center">
-                            <GhostButton
-                              size="md"
-                              onClick={() => subButtonOptions.onClick?.({ close: closeModal })}
-                              disabled={subButtonOptions.disabled}
-                              IconComponent={subButtonOptions.IconComponent}
-                            >
-                              {subButtonOptions.text}
-                            </GhostButton>
-                          </Box>
-                        </VStack>
-                      )}
+                        </Stack>
+                        {isDefined(subButtonOptions) && subButton}
+                      </VStack>
+                    )}
                   </Box>
                 </ScrollBox>
               </Animated.View>

--- a/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.stories.tsx
+++ b/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.stories.tsx
@@ -145,7 +145,7 @@ export const MultipleModal: ComponentStory<typeof ModalBottomSheet> = () => {
   );
 };
 
-export const withButtonOptions: ComponentStory<typeof ModalBottomSheet> = () => (
+export const withButtonOptions: ComponentStory<typeof ModalBottomSheet> = props => (
   <HStack mt={200} width="100%" spacing={20}>
     <ModalBottomSheet
       title=""
@@ -167,6 +167,8 @@ export const withButtonOptions: ComponentStory<typeof ModalBottomSheet> = () => 
       )}
       primaryButtonOptions={{ text: 'primary', disabled: false }}
       secondaryButtonOptions={{ text: 'secondary', disabled: false }}
+      subButtonOptions={{ text: 'sub', disabled: false }}
+      buttonDirection={props.buttonDirection}
     />
     <ModalBottomSheet
       title=""

--- a/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.stories.tsx
+++ b/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.stories.tsx
@@ -167,7 +167,6 @@ export const withButtonOptions: ComponentStory<typeof ModalBottomSheet> = props 
       )}
       primaryButtonOptions={{ text: 'primary', disabled: false }}
       secondaryButtonOptions={{ text: 'secondary', disabled: false }}
-      subButtonOptions={{ text: 'sub', disabled: false }}
       buttonDirection={props.buttonDirection}
     />
     <ModalBottomSheet
@@ -180,6 +179,19 @@ export const withButtonOptions: ComponentStory<typeof ModalBottomSheet> = props 
       )}
       primaryButtonOptions={{ text: 'primary', disabled: false }}
       subButtonOptions={{ text: 'sub', disabled: false }}
+    />
+    <ModalBottomSheet
+      title=""
+      defaultOpen={false}
+      renderOpener={({ open }) => (
+        <ContainedButton kind="primary" size="md" onClick={open}>
+          Primary + Secondary + Sub
+        </ContainedButton>
+      )}
+      primaryButtonOptions={{ text: 'primary', disabled: false }}
+      secondaryButtonOptions={{ text: 'secondary', disabled: false }}
+      subButtonOptions={{ text: 'sub', disabled: false }}
+      buttonDirection={props.buttonDirection}
     />
   </HStack>
 );

--- a/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.tsx
+++ b/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.tsx
@@ -277,6 +277,7 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
                       width="100%"
                       spacing={8}
                       direction={buttonDirection}
+                      reverse={buttonDirection === 'horizontal' ? true : false}
                     >
                       <ContainedButton
                         kind={primaryButtonOptions.kind ?? 'primary'}

--- a/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.tsx
+++ b/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.tsx
@@ -196,7 +196,15 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
                   )}
                 </HStack>
                 {subtitle ? (
-                  <Body as="p" level={1} mt={[14, 20]} px={[20, 32]} flexShrink={0} whiteSpace="pre-wrap">
+                  <Body
+                    as="p"
+                    level={1}
+                    mt={[14, 20]}
+                    px={[20, 32]}
+                    flexShrink={0}
+                    whiteSpace="pre-wrap"
+                    color="onView2"
+                  >
                     {subtitle}
                   </Body>
                 ) : null}

--- a/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.tsx
+++ b/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.tsx
@@ -134,8 +134,7 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
       return () => window.removeEventListener('keydown', onKeydown);
     }, [closeModal, isOpen, dimClosable, showCloseButton]);
 
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    const SubButton = useMemo(
+    const subButton = useMemo(
       () =>
         subButtonOptions ? (
           <Box alignSelf="center" mt={12}>
@@ -248,7 +247,7 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
                     >
                       {primaryButtonOptions.text}
                     </ContainedButton>
-                    {isDefined(subButtonOptions) && SubButton}
+                    {isDefined(subButtonOptions) && subButton}
                   </VStack>
                 )}
 
@@ -265,7 +264,7 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
                     >
                       {secondaryButtonOptions.text}
                     </ContainedButton>
-                    {isDefined(subButtonOptions) && SubButton}
+                    {isDefined(subButtonOptions) && subButton}
                   </VStack>
                 )}
 
@@ -302,7 +301,7 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
                         {secondaryButtonOptions.text}
                       </ContainedButton>
                     </Stack>
-                    {isDefined(subButtonOptions) && SubButton}
+                    {isDefined(subButtonOptions) && subButton}
                   </VStack>
                 )}
               </Box>

--- a/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.tsx
+++ b/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheet.tsx
@@ -21,6 +21,7 @@ import { ContainedButton } from '../ContainedButton';
 import { GhostButton } from '../GhostButton';
 import { HStack } from '../HStack';
 import { IconButton } from '../IconButton';
+import { Stack } from '../Stack';
 import { Title } from '../Title';
 import { VStack } from '../VStack';
 import { withModalBottomSheetVariation } from './ModalBottomSheetProps';
@@ -37,6 +38,7 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
     primaryButtonOptions,
     secondaryButtonOptions,
     subButtonOptions,
+    buttonDirection = 'vertical',
     onClose,
     showCloseButton = true,
     dimClosable = true,
@@ -132,6 +134,24 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
       return () => window.removeEventListener('keydown', onKeydown);
     }, [closeModal, isOpen, dimClosable, showCloseButton]);
 
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const SubButton = useMemo(
+      () =>
+        subButtonOptions ? (
+          <Box alignSelf="center" mt={12}>
+            <GhostButton
+              size="md"
+              onClick={() => subButtonOptions.onClick?.({ close: closeModal })}
+              disabled={subButtonOptions.disabled}
+              IconComponent={subButtonOptions.IconComponent}
+            >
+              {subButtonOptions.text}
+            </GhostButton>
+          </Box>
+        ) : null,
+      [closeModal, subButtonOptions]
+    );
+
     return (
       <>
         {opener}
@@ -215,7 +235,7 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
                   </ScrollBox>
                 )}
 
-                {isDefined(primaryButtonOptions) && !isDefined(secondaryButtonOptions) && !isDefined(subButtonOptions) && (
+                {isDefined(primaryButtonOptions) && !isDefined(secondaryButtonOptions) && (
                   <VStack px={[20, 32]} mt={[20, 24]} flexShrink={0}>
                     <ContainedButton
                       kind={primaryButtonOptions.kind ?? 'primary'}
@@ -228,21 +248,12 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
                     >
                       {primaryButtonOptions.text}
                     </ContainedButton>
+                    {isDefined(subButtonOptions) && SubButton}
                   </VStack>
                 )}
-                {isDefined(primaryButtonOptions) && isDefined(secondaryButtonOptions) && !isDefined(subButtonOptions) && (
-                  <VStack px={[20, 32]} mt={[20, 24]} flexShrink={0} width="100%" spacing={8}>
-                    <ContainedButton
-                      kind={primaryButtonOptions.kind ?? 'primary'}
-                      size="xl"
-                      onClick={() => primaryButtonOptions.onClick?.({ close: closeModal })}
-                      full={true}
-                      disabled={primaryButtonOptions.disabled}
-                      loading={primaryButtonOptions.loading}
-                      IconComponent={primaryButtonOptions.IconComponent}
-                    >
-                      {primaryButtonOptions.text}
-                    </ContainedButton>
+
+                {!isDefined(primaryButtonOptions) && isDefined(secondaryButtonOptions) && (
+                  <VStack px={[20, 32]} mt={[20, 24]} flexShrink={0}>
                     <ContainedButton
                       kind={secondaryButtonOptions.kind ?? 'tertiary'}
                       size="xl"
@@ -254,31 +265,44 @@ export const ModalBottomSheet = withModalBottomSheetVariation(
                     >
                       {secondaryButtonOptions.text}
                     </ContainedButton>
+                    {isDefined(subButtonOptions) && SubButton}
                   </VStack>
                 )}
-                {isDefined(primaryButtonOptions) && !isDefined(secondaryButtonOptions) && isDefined(subButtonOptions) && (
-                  <VStack px={[20, 32]} mt={[20, 24]} flexShrink={0} width="100%" spacing={16}>
-                    <ContainedButton
-                      kind={primaryButtonOptions.kind ?? 'primary'}
-                      size="xl"
-                      onClick={() => primaryButtonOptions.onClick?.({ close: closeModal })}
-                      full={true}
-                      disabled={primaryButtonOptions.disabled}
-                      loading={primaryButtonOptions.loading}
-                      IconComponent={primaryButtonOptions.IconComponent}
+
+                {isDefined(primaryButtonOptions) && isDefined(secondaryButtonOptions) && (
+                  <VStack>
+                    <Stack
+                      px={[20, 32]}
+                      mt={[20, 24]}
+                      flexShrink={0}
+                      width="100%"
+                      spacing={8}
+                      direction={buttonDirection}
                     >
-                      {primaryButtonOptions.text}
-                    </ContainedButton>
-                    <Box alignSelf="center">
-                      <GhostButton
-                        size="md"
-                        onClick={() => subButtonOptions.onClick?.({ close: closeModal })}
-                        disabled={subButtonOptions.disabled}
-                        IconComponent={subButtonOptions.IconComponent}
+                      <ContainedButton
+                        kind={primaryButtonOptions.kind ?? 'primary'}
+                        size="xl"
+                        onClick={() => primaryButtonOptions.onClick?.({ close: closeModal })}
+                        full={true}
+                        disabled={primaryButtonOptions.disabled}
+                        loading={primaryButtonOptions.loading}
+                        IconComponent={primaryButtonOptions.IconComponent}
                       >
-                        {subButtonOptions.text}
-                      </GhostButton>
-                    </Box>
+                        {primaryButtonOptions.text}
+                      </ContainedButton>
+                      <ContainedButton
+                        kind={secondaryButtonOptions.kind ?? 'tertiary'}
+                        size="xl"
+                        onClick={() => secondaryButtonOptions.onClick?.({ close: closeModal })}
+                        full={true}
+                        disabled={secondaryButtonOptions.disabled}
+                        loading={secondaryButtonOptions.loading}
+                        IconComponent={secondaryButtonOptions.IconComponent}
+                      >
+                        {secondaryButtonOptions.text}
+                      </ContainedButton>
+                    </Stack>
+                    {isDefined(subButtonOptions) && SubButton}
                   </VStack>
                 )}
               </Box>

--- a/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheetProps.ts
+++ b/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheetProps.ts
@@ -35,23 +35,23 @@ export type ModalBottomSheetProps = Either<
    * @default 200
    */
   native_swipeToCloseVelocity?: number;
-} & (NoButtons | PrimaryOnly | PrimarySecondary | SecondaryOnly);
+} & (NoButtons | PrimaryButtonOnly | PrimarySecondaryButtons | SecondaryButtonOnly);
 
-type PrimaryOnly = {
+type PrimaryButtonOnly = {
   primaryButtonOptions: ButtonOptions;
   secondaryButtonOptions?: never;
   subButtonOptions?: Omit<ButtonOptions, 'kind' | 'loading'>;
   buttonDirection?: never;
 };
 
-type SecondaryOnly = {
+type SecondaryButtonOnly = {
   primaryButtonOptions?: never;
   secondaryButtonOptions: ButtonOptions;
   subButtonOptions?: Omit<ButtonOptions, 'kind' | 'loading'>;
   buttonDirection?: never;
 };
 
-type PrimarySecondary = {
+type PrimarySecondaryButtons = {
   primaryButtonOptions: ButtonOptions;
   secondaryButtonOptions: ButtonOptions;
   subButtonOptions?: Omit<ButtonOptions, 'kind' | 'loading'>;

--- a/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheetProps.ts
+++ b/packages/vibrant-components/src/lib/ModalBottomSheet/ModalBottomSheetProps.ts
@@ -35,23 +35,35 @@ export type ModalBottomSheetProps = Either<
    * @default 200
    */
   native_swipeToCloseVelocity?: number;
-} & (
-    | {
-        primaryButtonOptions: ButtonOptions;
-        secondaryButtonOptions?: ButtonOptions;
-        subButtonOptions?: never;
-      }
-    | {
-        primaryButtonOptions: ButtonOptions;
-        secondaryButtonOptions?: never;
-        subButtonOptions?: Omit<ButtonOptions, 'kind' | 'loading'>;
-      }
-    | {
-        primaryButtonOptions?: never;
-        secondaryButtonOptions?: never;
-        subButtonOptions?: never;
-      }
-  );
+} & (NoButtons | PrimaryOnly | PrimarySecondary | SecondaryOnly);
+
+type PrimaryOnly = {
+  primaryButtonOptions: ButtonOptions;
+  secondaryButtonOptions?: never;
+  subButtonOptions?: Omit<ButtonOptions, 'kind' | 'loading'>;
+  buttonDirection?: never;
+};
+
+type SecondaryOnly = {
+  primaryButtonOptions?: never;
+  secondaryButtonOptions: ButtonOptions;
+  subButtonOptions?: Omit<ButtonOptions, 'kind' | 'loading'>;
+  buttonDirection?: never;
+};
+
+type PrimarySecondary = {
+  primaryButtonOptions: ButtonOptions;
+  secondaryButtonOptions: ButtonOptions;
+  subButtonOptions?: Omit<ButtonOptions, 'kind' | 'loading'>;
+  buttonDirection?: 'horizontal' | 'vertical';
+};
+
+type NoButtons = {
+  primaryButtonOptions?: never;
+  secondaryButtonOptions?: never;
+  subButtonOptions?: never;
+  buttonDirection?: never;
+};
 
 export type ButtonOptions = {
   kind?: 'primary' | 'secondary' | 'tertiary';


### PR DESCRIPTION
https://www.figma.com/design/BPv3p1SEYUKhuKyYW3syfTgq/--Vibrant-Component?m=dev


subtitle 색상을 변경합니다 onView1 -> onView2

| before | after |
|---|---|
| <img width="774" alt="스크린샷 2025-06-02 오후 4 45 00" src="https://github.com/user-attachments/assets/60b51272-b4b6-4c41-b5c1-99a1a92dd22e" />  | <img width="753" alt="스크린샷 2025-06-02 오후 4 45 29" src="https://github.com/user-attachments/assets/01068ce3-76d5-48c8-a25b-23de806019b5" /> |


버튼 스펙을 변경합니다.
buttonDirection prop을 추가하여 수평 정렬이 가능하게 수정합니다.
버튼 사용 제약 조건을 수정합니다.

https://github.com/user-attachments/assets/b3486066-0944-410c-b3e9-29219a536d59

<img width="583" alt="스크린샷 2025-06-04 오후 5 57 24" src="https://github.com/user-attachments/assets/7518ae27-43b9-4e30-bf8d-198ddb8a8b74" />


앱 환경 테스트

<img  src="https://github.com/user-attachments/assets/dbea265d-cf63-47ba-9c94-97ee5dbc76ac" width="200" />

